### PR TITLE
[CORE] ArmorStandEditor 1.20-44: Fixes and New UI!

### DIFF
--- a/API-Example-Plugin/src/main/java/io/github/rypofalem/apiexample/ASEventTester.java
+++ b/API-Example-Plugin/src/main/java/io/github/rypofalem/apiexample/ASEventTester.java
@@ -29,66 +29,66 @@ import org.bukkit.event.player.PlayerSwapHandItemsEvent;
 
 public class ASEventTester implements Listener {
 
-	Player player;
+    Player player;
 
-	//ArmorStandRenameEvent
-	@EventHandler
-	public void renameArmorStand(PlayerInteractAtEntityEvent ASRenameEvent){
-		player = ASRenameEvent.getPlayer();
-		ASRenameEvent.setCancelled(true);
-		if(ASRenameEvent.isCancelled()) {
-			player.sendMessage("ArmorStandRenameEvent has been cancelled");
-		} else{
-			player.sendMessage("ArmorStandRenameEvent has not been cancelled. Continuing....");
-		}
-	}
+    //ArmorStandRenameEvent
+    @EventHandler
+    public void renameArmorStand(PlayerInteractAtEntityEvent ASRenameEvent) {
+        player = ASRenameEvent.getPlayer();
+        ASRenameEvent.setCancelled(true);
+        if (ASRenameEvent.isCancelled()) {
+            player.sendMessage("ArmorStandRenameEvent has been cancelled");
+        } else {
+            player.sendMessage("ArmorStandRenameEvent has not been cancelled. Continuing....");
+        }
+    }
 
-	//ArmorStandManipEvent
-	@EventHandler
-	public void manipulateArmorStand(PlayerInteractAtEntityEvent ASManipEvent){
-		player = ASManipEvent.getPlayer();
-		ASManipEvent.setCancelled(true);
-		if(ASManipEvent.isCancelled()) {
-			player.sendMessage("ArmorStandManipulationEvent has been cancelled");
-		} else{
-			player.sendMessage("ArmorStandManipulationEvent has not been cancelled. Continuing....");
-		}
-	}
+    //ArmorStandManipEvent
+    @EventHandler
+    public void manipulateArmorStand(PlayerInteractAtEntityEvent ASManipEvent) {
+        player = ASManipEvent.getPlayer();
+        ASManipEvent.setCancelled(true);
+        if (ASManipEvent.isCancelled()) {
+            player.sendMessage("ArmorStandManipulationEvent has been cancelled");
+        } else {
+            player.sendMessage("ArmorStandManipulationEvent has not been cancelled. Continuing....");
+        }
+    }
 
-	//ArmorStandTargetedEvent
-	@EventHandler
-	public void targetEvent(PlayerSwapHandItemsEvent targetASEvent){
-		player = targetASEvent.getPlayer();
-		targetASEvent.setCancelled(true);
-		if(targetASEvent.isCancelled()) {
-			player.sendMessage("ArmorStandTargetedEvent has been cancelled");
-		} else{
-			player.sendMessage("ArmorStandTargetedEvent has not been cancelled. Continuing....");
-		}
-	}
+    //ArmorStandTargetedEvent
+    @EventHandler
+    public void targetEvent(PlayerSwapHandItemsEvent targetASEvent) {
+        player = targetASEvent.getPlayer();
+        targetASEvent.setCancelled(true);
+        if (targetASEvent.isCancelled()) {
+            player.sendMessage("ArmorStandTargetedEvent has been cancelled");
+        } else {
+            player.sendMessage("ArmorStandTargetedEvent has not been cancelled. Continuing....");
+        }
+    }
 
-	//PlayerOpenMenuEvent
-	//onArmorStandDamage EntityDamageByEntityEvent event
-	@EventHandler
-	public void playerOpeningMenuEvent(EntityDamageByEntityEvent ASEDamageMenuOpenEvent){
-		player = (Player) ASEDamageMenuOpenEvent.getDamager();
-		ASEDamageMenuOpenEvent.setCancelled(true);
-		if(ASEDamageMenuOpenEvent.isCancelled()) {
-			player.sendMessage("PlayerOpenMenuEvent has been cancelled");
-		} else{
-			player.sendMessage("PlayerOpenMenuEvent has not been cancelled. Continuing....");
-		}
-	}
+    //PlayerOpenMenuEvent
+    //onArmorStandDamage EntityDamageByEntityEvent event
+    @EventHandler
+    public void playerOpeningMenuEvent(EntityDamageByEntityEvent ASEDamageMenuOpenEvent) {
+        player = (Player) ASEDamageMenuOpenEvent.getDamager();
+        ASEDamageMenuOpenEvent.setCancelled(true);
+        if (ASEDamageMenuOpenEvent.isCancelled()) {
+            player.sendMessage("PlayerOpenMenuEvent has been cancelled");
+        } else {
+            player.sendMessage("PlayerOpenMenuEvent has not been cancelled. Continuing....");
+        }
+    }
 
-	//Also PlayerOpenMenuEvent when RightClicking/Interacting
-	@EventHandler
-	public void playerOpeningMenuRightClickEvent(PlayerInteractEvent ASERightClickMenuOpenEvent){
-		player = ASERightClickMenuOpenEvent.getPlayer();
-		ASERightClickMenuOpenEvent.setCancelled(true);
-		if(ASERightClickMenuOpenEvent.isCancelled()) {
-			player.sendMessage("PlayerOpenMenuEvent has been cancelled");
-		} else{
-			player.sendMessage("PlayerOpenMenuEvent has not been cancelled. Continuing....");
-		}
-	}
+    //Also PlayerOpenMenuEvent when RightClicking/Interacting
+    @EventHandler
+    public void playerOpeningMenuRightClickEvent(PlayerInteractEvent ASERightClickMenuOpenEvent) {
+        player = ASERightClickMenuOpenEvent.getPlayer();
+        ASERightClickMenuOpenEvent.setCancelled(true);
+        if (ASERightClickMenuOpenEvent.isCancelled()) {
+            player.sendMessage("PlayerOpenMenuEvent has been cancelled");
+        } else {
+            player.sendMessage("PlayerOpenMenuEvent has not been cancelled. Continuing....");
+        }
+    }
 }

--- a/API-Example-Plugin/src/main/java/io/github/rypofalem/apiexample/ArmorStandEditorAPITest.java
+++ b/API-Example-Plugin/src/main/java/io/github/rypofalem/apiexample/ArmorStandEditorAPITest.java
@@ -23,11 +23,11 @@ import org.bukkit.plugin.java.JavaPlugin;
 
 public class ArmorStandEditorAPITest extends JavaPlugin {
 
-	@Override
-	public void onEnable(){
-		this.getLogger().info("[ArmorStandEditor] API Testing Plugin v1.20.0-43 - Enable");
-		this.getServer().getPluginManager().registerEvents(new ASEventTester(), this);
-		this.getServer().getPluginManager().registerEvents(new IFEventTester(), this);
-	}
+    @Override
+    public void onEnable() {
+        this.getLogger().info("[ArmorStandEditor] API Testing Plugin v1.20.0-43 - Enable");
+        this.getServer().getPluginManager().registerEvents(new ASEventTester(), this);
+        this.getServer().getPluginManager().registerEvents(new IFEventTester(), this);
+    }
 
 }

--- a/API-Example-Plugin/src/main/java/io/github/rypofalem/apiexample/IFEventTester.java
+++ b/API-Example-Plugin/src/main/java/io/github/rypofalem/apiexample/IFEventTester.java
@@ -27,51 +27,51 @@ import org.bukkit.event.player.PlayerInteractAtEntityEvent;
 import org.bukkit.event.player.PlayerSwapHandItemsEvent;
 
 public class IFEventTester implements Listener {
-	Player player;
+    Player player;
 
-	//ItemFrameGlowEvent
-	@EventHandler
-	public void manipulateArmorStand(PlayerInteractAtEntityEvent IFGlowEvent){
-		player = IFGlowEvent.getPlayer();
-		IFGlowEvent.setCancelled(true);
-		if(IFGlowEvent.isCancelled()) {
-			player.sendMessage("ItemFrameGlowEvent has been cancelled");
-		} else{
-			player.sendMessage("ItemFrameGlowEvent has not been cancelled. Continuing....");
-		}
-	}
+    //ItemFrameGlowEvent
+    @EventHandler
+    public void manipulateArmorStand(PlayerInteractAtEntityEvent IFGlowEvent) {
+        player = IFGlowEvent.getPlayer();
+        IFGlowEvent.setCancelled(true);
+        if (IFGlowEvent.isCancelled()) {
+            player.sendMessage("ItemFrameGlowEvent has been cancelled");
+        } else {
+            player.sendMessage("ItemFrameGlowEvent has not been cancelled. Continuing....");
+        }
+    }
 
-	@EventHandler
-	public void manipulateItemFrame(EntityDamageByEntityEvent IFManipulationLeftClickEvent){
-		player = (Player) IFManipulationLeftClickEvent.getDamager();
-		IFManipulationLeftClickEvent.setCancelled(true);
-		if(IFManipulationLeftClickEvent.isCancelled()) {
-			player.sendMessage("ItemFrameManipulatedEvent has been cancelled");
-		} else{
-			player.sendMessage("ItemFrameManipulatedEvent has not been cancelled. Continuing....");
-		}
-	}
+    @EventHandler
+    public void manipulateItemFrame(EntityDamageByEntityEvent IFManipulationLeftClickEvent) {
+        player = (Player) IFManipulationLeftClickEvent.getDamager();
+        IFManipulationLeftClickEvent.setCancelled(true);
+        if (IFManipulationLeftClickEvent.isCancelled()) {
+            player.sendMessage("ItemFrameManipulatedEvent has been cancelled");
+        } else {
+            player.sendMessage("ItemFrameManipulatedEvent has not been cancelled. Continuing....");
+        }
+    }
 
-	@EventHandler
-	public void manipulateItemFrameRightClick(PlayerInteractAtEntityEvent IFManipulationRightClickEvent){
-		player = IFManipulationRightClickEvent.getPlayer();
-		IFManipulationRightClickEvent.setCancelled(true);
-		if(IFManipulationRightClickEvent.isCancelled()) {
-			player.sendMessage("ItemFrameManipulatedEvent has been cancelled");
-		} else{
-			player.sendMessage("ItemFrameManipulatedEvent has not been cancelled. Continuing....");
-		}
-	}
+    @EventHandler
+    public void manipulateItemFrameRightClick(PlayerInteractAtEntityEvent IFManipulationRightClickEvent) {
+        player = IFManipulationRightClickEvent.getPlayer();
+        IFManipulationRightClickEvent.setCancelled(true);
+        if (IFManipulationRightClickEvent.isCancelled()) {
+            player.sendMessage("ItemFrameManipulatedEvent has been cancelled");
+        } else {
+            player.sendMessage("ItemFrameManipulatedEvent has not been cancelled. Continuing....");
+        }
+    }
 
-	@EventHandler
-	public void targetEvent(PlayerSwapHandItemsEvent targetIFEvent){
-		player = targetIFEvent.getPlayer();
-		targetIFEvent.setCancelled(true);
-		if(targetIFEvent.isCancelled()) {
-			player.sendMessage("ItemFrameTargetedEvent has been cancelled");
-		} else{
-			player.sendMessage("ItemFrameTargetedEvent has not been cancelled. Continuing....");
-		}
-	}
+    @EventHandler
+    public void targetEvent(PlayerSwapHandItemsEvent targetIFEvent) {
+        player = targetIFEvent.getPlayer();
+        targetIFEvent.setCancelled(true);
+        if (targetIFEvent.isCancelled()) {
+            player.sendMessage("ItemFrameTargetedEvent has been cancelled");
+        } else {
+            player.sendMessage("ItemFrameTargetedEvent has not been cancelled. Continuing....");
+        }
+    }
 
 }

--- a/API-Example-Plugin/src/main/resources/plugin.yml
+++ b/API-Example-Plugin/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: ArmorStandEditor-APITester
 main: io.github.rypofalem.apiexample.ArmorStandEditorAPITest
-version: 1.20.0-43
+version: 1.20.1-43.2
 api-version: "1.13"
 website: https://www.spigotmc.org/resources/94503/
 authors: [Wolfstorm, Pinnkk]

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.github.rypofalem.armorstandeditor</groupId>
     <artifactId>armorstandeditor</artifactId>
     <packaging>jar</packaging>
-    <version>1.20.1-44</version>
+    <version>1.20.2-44</version>
     <name>armorstandeditor</name>
     <url>http://maven.apache.org</url>
 
@@ -106,7 +106,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.20.1-R0.1-SNAPSHOT</version>
+            <version>1.20.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
         <dependency>
             <groupId>com.github.angeschossen</groupId>
             <artifactId>LandsAPI</artifactId>
-            <version>6.34.0</version>
+            <version>6.35.0</version>
             <scope>provided</scope>
         </dependency>
         <!-- Bentobox -->

--- a/pom.xml
+++ b/pom.xml
@@ -259,14 +259,14 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
-        <configuration>
-          <release>${java.version}</release>
+                <configuration>
+                    <release>${java.version}</release>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.5.1</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -266,7 +266,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>3.5.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -217,6 +217,11 @@
                 <configuration>
                     <activeRecipes>
                         <recipe>org.openrewrite.java.migrate.UpgradeToJava17</recipe>
+                        <recipe>org.openrewrite.java.format.AutoFormat</recipe>
+                        <recipe>org.openrewrite.java.recipes.FindRecipes</recipe>
+                        <recipe>org.openrewrite.java.OrderImports</recipe>
+                        <recipe>org.openrewrite.java.ShortenFullyQualifiedTypeReferences</recipe>
+                        <recipe>org.openrewrite.java.RemoveUnusedImports</recipe>
                     </activeRecipes>
                 </configuration>
                 <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -217,11 +217,6 @@
                 <configuration>
                     <activeRecipes>
                         <recipe>org.openrewrite.java.migrate.UpgradeToJava17</recipe>
-                        <recipe>org.openrewrite.java.format.AutoFormat</recipe>
-                        <recipe>org.openrewrite.java.recipes.FindRecipes</recipe>
-                        <recipe>org.openrewrite.java.OrderImports</recipe>
-                        <recipe>org.openrewrite.java.ShortenFullyQualifiedTypeReferences</recipe>
-                        <recipe>org.openrewrite.java.RemoveUnusedImports</recipe>
                     </activeRecipes>
                 </configuration>
                 <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.28</version>
+            <version>1.18.30</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.github.rypofalem.armorstandeditor</groupId>
     <artifactId>armorstandeditor</artifactId>
     <packaging>jar</packaging>
-    <version>1.20.2-44</version>
+    <version>1.20.x-44</version>
     <name>armorstandeditor</name>
     <url>http://maven.apache.org</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
         <dependency>
             <groupId>com.palmergames.bukkit.towny</groupId>
             <artifactId>towny</artifactId>
-            <version>0.99.5.17</version>
+            <version>0.99.5.20</version>
             <scope>provided</scope>
         </dependency>
         <!--- UpdateChecker -->

--- a/pom.xml
+++ b/pom.xml
@@ -198,6 +198,7 @@
             <version>4.0.43</version>
             <scope>provided</scope>
         </dependency>
+
         <!-- Lombok Support -->
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -209,6 +210,23 @@
     <!--Java 8-->
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.openrewrite.maven</groupId>
+                <artifactId>rewrite-maven-plugin</artifactId>
+                <version>5.4.1</version>
+                <configuration>
+                    <activeRecipes>
+                        <recipe>org.openrewrite.java.migrate.UpgradeToJava17</recipe>
+                    </activeRecipes>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.openrewrite.recipe</groupId>
+                        <artifactId>rewrite-migrate-java</artifactId>
+                        <version>2.0.9</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
@@ -236,9 +254,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
-                <configuration>
-                    <source>17</source>
-                    <target>17</target>
+        <configuration>
+          <release>${java.version}</release>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.github.rypofalem.armorstandeditor</groupId>
     <artifactId>armorstandeditor</artifactId>
     <packaging>jar</packaging>
-    <version>1.20.1-43.2</version>
+    <version>1.20.1-44</version>
     <name>armorstandeditor</name>
     <url>http://maven.apache.org</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -126,14 +126,14 @@
         <dependency>
             <groupId>com.intellectualsites.plotsquared</groupId>
             <artifactId>plotsquared-core</artifactId>
-            <version>7.0.0</version>
+            <version>7.1.0</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>com.intellectualsites.plotsquared</groupId>
             <artifactId>plotsquared-bukkit</artifactId>
-            <version>7.0.0</version>
+            <version>7.1.0</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -153,7 +153,7 @@
         <dependency>
             <groupId>com.palmergames.bukkit.towny</groupId>
             <artifactId>towny</artifactId>
-            <version>0.99.5.20</version>
+            <version>0.99.6.1</version>
             <scope>provided</scope>
         </dependency>
         <!--- UpdateChecker -->

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,6 @@
             <version>7.1.0</version>
             <scope>provided</scope>
         </dependency>
-
         <dependency>
             <groupId>com.intellectualsites.plotsquared</groupId>
             <artifactId>plotsquared-bukkit</artifactId>

--- a/src/main/java/io/github/rypofalem/armorstandeditor/ArmorStandEditorPlugin.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/ArmorStandEditorPlugin.java
@@ -19,9 +19,12 @@
 
 package io.github.rypofalem.armorstandeditor;
 
-import io.github.rypofalem.armorstandeditor.language.Language;
-import com.jeff_media.updatechecker.*;
+import com.jeff_media.updatechecker.UpdateCheckSource;
+import com.jeff_media.updatechecker.UpdateChecker;
+import com.jeff_media.updatechecker.UserAgentBuilder;
+
 import io.github.rypofalem.armorstandeditor.Metrics.*;
+import io.github.rypofalem.armorstandeditor.language.Language;
 
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -40,7 +43,7 @@ import java.io.File;
 import java.util.*;
 import java.util.logging.Level;
 
-public class ArmorStandEditorPlugin extends JavaPlugin{
+public class ArmorStandEditorPlugin extends JavaPlugin {
 
     //!!! DO NOT REMOVE THESE UNDER ANY CIRCUMSTANCES - Required for BStats and UpdateChecker !!!
     public static final int SPIGOT_RESOURCE_ID = 94503;  //Used for Update Checker
@@ -49,7 +52,7 @@ public class ArmorStandEditorPlugin extends JavaPlugin{
     private NamespacedKey iconKey;
     private static ArmorStandEditorPlugin instance;
     private Language lang;
-    
+
     //Server Version Detection: Paper or Spigot and Invalid NMS Version
     String nmsVersion;
     String languageFolderLocation = "lang/";
@@ -61,7 +64,7 @@ public class ArmorStandEditorPlugin extends JavaPlugin{
     static final String SEPARATOR_FIELD = "================================";
 
     public PlayerEditorManager editorManager;
-    
+
     //Output for Updates
     boolean opUpdateNotification = false;
     boolean runTheUpdateChecker = false;
@@ -78,11 +81,11 @@ public class ArmorStandEditorPlugin extends JavaPlugin{
     List<?> editToolLore = null;
     boolean allowCustomModelData = false;
     Integer customModelDataInt = Integer.MIN_VALUE;
-    
+
     //GUI Settings
     boolean requireSneaking = false;
     boolean sendToActionBar = true;
-    
+
     //Armor Stand Specific Settings
     double coarseRot;
     double fineRot;
@@ -101,7 +104,7 @@ public class ArmorStandEditorPlugin extends JavaPlugin{
 
     private static ArmorStandEditorPlugin plugin;
 
-    public ArmorStandEditorPlugin(){
+    public ArmorStandEditorPlugin() {
         instance = this;
     }
 
@@ -120,7 +123,7 @@ public class ArmorStandEditorPlugin extends JavaPlugin{
 
         // Check if the Minecraft version is supported
         if (nmsVersion.compareTo("v1_17") < 0) {
-            getLogger().log(Level.WARNING,warningMCVer + "{0}",nmsVersion);
+            getLogger().log(Level.WARNING, warningMCVer + "{0}", nmsVersion);
             getLogger().warning("ArmorStandEditor is not compatible with this version of Minecraft. Please update to at least version 1.17. Loading failed.");
             getServer().getPluginManager().disablePlugin(this);
             getLogger().info(SEPARATOR_FIELD);
@@ -129,11 +132,11 @@ public class ArmorStandEditorPlugin extends JavaPlugin{
 
         //Also Warn People to Update if using nmsVersion lower than latest
         if (nmsVersion.compareTo("v1_20") < 0) {
-            getLogger().log(Level.WARNING,warningMCVer + "{0}",nmsVersion);
+            getLogger().log(Level.WARNING, warningMCVer + "{0}", nmsVersion);
             getLogger().warning("ArmorStandEditor is compatible with this version of Minecraft, but it is not the latest supported version.");
             getLogger().warning("Loading continuing, but please consider updating to the latest version.");
         } else {
-            getLogger().log(Level.INFO,warningMCVer + "{0}",nmsVersion);
+            getLogger().log(Level.INFO, warningMCVer + "{0}", nmsVersion);
             getLogger().info("ArmorStandEditor is compatible with this version of Minecraft. Loading continuing.");
         }
         //Spigot Check
@@ -141,16 +144,16 @@ public class ArmorStandEditorPlugin extends JavaPlugin{
         hasPaper = getHasPaper();
 
         //If Paper and Spigot are both FALSE - Disable the plugin
-        if (!hasPaper && !hasSpigot){
+        if (!hasPaper && !hasSpigot) {
             getLogger().severe("This plugin requires either Paper, Spigot or one of its forks to run. This is not an error, please do not report this!");
             getServer().getPluginManager().disablePlugin(this);
             getLogger().info(SEPARATOR_FIELD);
             return;
         } else {
             if (hasSpigot) {
-                getLogger().log(Level.INFO,"SpigotMC: {0}",hasSpigot);
+                getLogger().log(Level.INFO, "SpigotMC: {0}", hasSpigot);
             } else {
-                getLogger().log(Level.INFO,"PaperMC: {0}",hasPaper);
+                getLogger().log(Level.INFO, "PaperMC: {0}", hasPaper);
             }
         }
 
@@ -191,18 +194,18 @@ public class ArmorStandEditorPlugin extends JavaPlugin{
             getServer().getPluginManager().disablePlugin(this);
             return;
         }
-        
+
         //Do we require a custom tool name?
         requireToolName = getConfig().getBoolean("requireToolName", false);
-        if(requireToolName){
+        if (requireToolName) {
             editToolName = getConfig().getString("toolName", null);
-            if(editToolName != null) editToolName = ChatColor.translateAlternateColorCodes('&', editToolName);
+            if (editToolName != null) editToolName = ChatColor.translateAlternateColorCodes('&', editToolName);
         }
 
         //Custom Model Data
         allowCustomModelData = getConfig().getBoolean("allowCustomModelData", false);
 
-        if(allowCustomModelData){
+        if (allowCustomModelData) {
             customModelDataInt = getConfig().getInt("customModelDataInt", Integer.MIN_VALUE);
         }
 
@@ -212,13 +215,13 @@ public class ArmorStandEditorPlugin extends JavaPlugin{
         //Is there NBT Required for the tool
         requireToolData = getConfig().getBoolean("requireToolData", false);
 
-        if(requireToolData) {
+        if (requireToolData) {
             editToolData = getConfig().getInt("toolData", Integer.MIN_VALUE);
         }
 
         requireToolLore = getConfig().getBoolean("requireToolLore", false);
 
-        if(requireToolLore) {
+        if (requireToolLore) {
             editToolLore = getConfig().getList("toolLore", null);
         }
 
@@ -246,9 +249,9 @@ public class ArmorStandEditorPlugin extends JavaPlugin{
         adminOnlyNotifications = getConfig().getBoolean("adminOnlyNotifications", true);
 
         //Run UpdateChecker - Reports out to Console on Startup ONLY!
-        if(!Scheduler.isFolia() && runTheUpdateChecker) {
+        if (!Scheduler.isFolia() && runTheUpdateChecker) {
 
-            if(opUpdateNotification){
+            if (opUpdateNotification) {
                 runUpdateCheckerWithOPNotifyOnJoinEnabled();
             } else {
                 runUpdateCheckerConsoleUpdateCheck();
@@ -280,12 +283,12 @@ public class ArmorStandEditorPlugin extends JavaPlugin{
             getLogger().info("Update Checker does not work on Development Builds.");
         } else {
             new UpdateChecker(this, UpdateCheckSource.SPIGET, "" + SPIGOT_RESOURCE_ID + "")
-                    .setDownloadLink("https://www.spigotmc.org/resources/armorstandeditor-reborn.94503/")
-                    .setChangelogLink("https://www.spigotmc.org/resources/armorstandeditor-reborn.94503/history")
-                    .setColoredConsoleOutput(true)
-                    .setUserAgent(new UserAgentBuilder().addPluginNameAndVersion().addServerVersion())
-                    .checkEveryXHours(updateCheckerInterval)
-                    .checkNow();
+                .setDownloadLink("https://www.spigotmc.org/resources/armorstandeditor-reborn.94503/")
+                .setChangelogLink("https://www.spigotmc.org/resources/armorstandeditor-reborn.94503/history")
+                .setColoredConsoleOutput(true)
+                .setUserAgent(new UserAgentBuilder().addPluginNameAndVersion().addServerVersion())
+                .checkEveryXHours(updateCheckerInterval)
+                .checkNow();
         }
     }
 
@@ -299,13 +302,13 @@ public class ArmorStandEditorPlugin extends JavaPlugin{
             getLogger().info("Update Checker does not work on Development Builds.");
         } else {
             new UpdateChecker(this, UpdateCheckSource.SPIGET, "" + SPIGOT_RESOURCE_ID + "")
-                    .setDownloadLink("https://www.spigotmc.org/resources/armorstandeditor-reborn.94503/")
-                    .setChangelogLink("https://www.spigotmc.org/resources/armorstandeditor-reborn.94503/history")
-                    .setColoredConsoleOutput(true)
-                    .setNotifyOpsOnJoin(true)
-                    .setUserAgent(new UserAgentBuilder().addPluginNameAndVersion().addServerVersion())
-                    .checkEveryXHours(updateCheckerInterval)
-                    .checkNow();
+                .setDownloadLink("https://www.spigotmc.org/resources/armorstandeditor-reborn.94503/")
+                .setChangelogLink("https://www.spigotmc.org/resources/armorstandeditor-reborn.94503/history")
+                .setColoredConsoleOutput(true)
+                .setNotifyOpsOnJoin(true)
+                .setUserAgent(new UserAgentBuilder().addPluginNameAndVersion().addServerVersion())
+                .checkEveryXHours(updateCheckerInterval)
+                .checkNow();
         }
     }
 
@@ -326,23 +329,23 @@ public class ArmorStandEditorPlugin extends JavaPlugin{
         getLogger().info("Removing Scoreboards required for Glowing Effects");
 
         team = scoreboard.getTeam(lockedTeam);
-        if(team != null) { //Basic Sanity Check to ensure that the team is there
+        if (team != null) { //Basic Sanity Check to ensure that the team is there
             team.unregister();
-        } else{
+        } else {
             getLogger().severe("Team Already Appears to be removed. Please do not do this manually!");
         }
     }
 
     private void updateConfig(String folder, String config) {
-        if(!new File(getDataFolder() + File.separator + folder + config).exists()){
+        if (!new File(getDataFolder() + File.separator + folder + config).exists()) {
             saveResource(folder  + config, false);
         }
     }
 
     @Override
-    public void onDisable(){
-        for(Player player : Bukkit.getServer().getOnlinePlayers()){
-            if(player.getOpenInventory().getTopInventory().getHolder() == editorManager.getMenuHolder()) player.closeInventory();
+    public void onDisable() {
+        for (Player player : Bukkit.getServer().getOnlinePlayers()) {
+            if (player.getOpenInventory().getTopInventory().getHolder() == editorManager.getMenuHolder()) player.closeInventory();
         }
 
         if (!Scheduler.isFolia()) {
@@ -351,45 +354,46 @@ public class ArmorStandEditorPlugin extends JavaPlugin{
         }
     }
 
-    public String getNmsVersion(){
-        return this.getServer().getClass().getPackage().getName().replace(".",",").split(",")[3];
+    public String getNmsVersion() {
+        return this.getServer().getClass().getPackage().getName().replace(".", ",").split(",")[3];
     }
 
-    public boolean getHasSpigot(){
+    public boolean getHasSpigot() {
         try {
             Class.forName("org.spigotmc.SpigotConfig");
             nmsVersionNotLatest = "SpigotMC ASAP.";
             return true;
-        } catch (ClassNotFoundException e){
+        } catch (ClassNotFoundException e) {
             nmsVersionNotLatest = "";
             return false;
         }
     }
 
-    public boolean getHasPaper(){
+    public boolean getHasPaper() {
         try {
             Class.forName("com.destroystokyo.paper.PaperConfig");
             nmsVersionNotLatest = "SpigotMC ASAP.";
             return true;
-        } catch (ClassNotFoundException e){
+        } catch (ClassNotFoundException e) {
             nmsVersionNotLatest = "";
             return false;
         }
     }
 
 
+    public String getArmorStandEditorVersion() {
+        return getConfig().getString("version");
+    }
 
-    public String getArmorStandEditorVersion(){ return getConfig().getString("version"); }
-
-    public boolean getArmorStandVisibility(){
+    public boolean getArmorStandVisibility() {
         return getConfig().getBoolean("armorStandVisibility");
     }
 
-    public boolean getItemFrameVisibility(){
+    public boolean getItemFrameVisibility() {
         return getConfig().getBoolean("invisibleItemFrames");
     }
 
-    public Language getLang(){
+    public Language getLang() {
         return lang;
     }
 
@@ -405,62 +409,86 @@ public class ArmorStandEditorPlugin extends JavaPlugin{
         return this.getConfig().getBoolean("runTheUpdateChecker");
     }
 
-    public Integer getCustomModelDataInt() { return this.getConfig().getInt("customModelDataInt"); }
+    public Integer getCustomModelDataInt() {
+        return this.getConfig().getInt("customModelDataInt");
+    }
 
     //New in 1.20-43: Allow the ability to get a player head from a command - ENABLED VIA CONFIG ONLY!
-    public boolean getAllowedToRetrievePlayerHead() { return this.getConfig().getBoolean("allowedToRetrievePlayerHead"); }
+    public boolean getAllowedToRetrievePlayerHead() {
+        return this.getConfig().getBoolean("allowedToRetrievePlayerHead");
+    }
 
-    public boolean getAdminOnlyNotifications() { return this.getConfig().getBoolean("adminOnlyNotifications"); }
+    public boolean getAdminOnlyNotifications() {
+        return this.getConfig().getBoolean("adminOnlyNotifications");
+    }
 
-    public boolean isEditTool(ItemStack itemStk){
-        if (itemStk == null) { return false; }
-        if (editTool != itemStk.getType()) { return false; }
+    public boolean isEditTool(ItemStack itemStk) {
+        if (itemStk == null) {
+            return false;
+        }
+        if (editTool != itemStk.getType()) {
+            return false;
+        }
 
         ItemMeta itemMeta = itemStk.getItemMeta();
-        if(itemMeta == null) return false;
+        if (itemMeta == null) return false;
 
         //FIX: Depreciated Stack for getDurability
-        if (requireToolData){
+        if (requireToolData) {
             Damageable d1 = (Damageable) itemMeta; //Get the Damageable Options for itemStk
             if (d1 != null) { //We do this to prevent NullPointers
-                if (d1.getDamage() != (short) editToolData) { return false; }
+                if (d1.getDamage() != (short) editToolData) {
+                    return false;
+                }
             }
         }
 
-        if(requireToolName && editToolName != null){
-            if(!itemStk.hasItemMeta()) { return false; }
+        if (requireToolName && editToolName != null) {
+            if (!itemStk.hasItemMeta()) {
+                return false;
+            }
 
             //Get the name of the Edit Tool - If Null, return false
             String itemName = itemMeta.getDisplayName();
 
             //If the name of the Edit Tool is not the Name specified in Config then Return false
-            if(!itemName.equals(editToolName)) { return false; }
+            if (!itemName.equals(editToolName)) {
+                return false;
+            }
 
         }
 
-        if(requireToolLore && editToolLore != null){
+        if (requireToolLore && editToolLore != null) {
 
             //If the ItemStack does not have Metadata then we return false
-            if(!itemStk.hasItemMeta()) { return false; }
+            if (!itemStk.hasItemMeta()) {
+                return false;
+            }
 
             //Get the lore of the Item and if it is null - Return False
             List<String> itemLore = itemMeta.getLore();
 
             //If the Item does not have Lore - Return False
             boolean hasTheItemLore = itemMeta.hasLore();
-            if (!hasTheItemLore)  { return false; }
+            if (!hasTheItemLore) {
+                return false;
+            }
 
             //Get the localised ListString of editToolLore
             List<String> listStringOfEditToolLore = (List<String>) editToolLore;
 
             //Return False if itemLore on the item does not match what we expect in the config.
-            if(!itemLore.equals(listStringOfEditToolLore)) { return false; }
+            if (!itemLore.equals(listStringOfEditToolLore)) {
+                return false;
+            }
 
         }
 
         if (allowCustomModelData && customModelDataInt != null) {
             //If the ItemStack does not have Metadata then we return false
-            if(!itemStk.hasItemMeta()) { return false; }
+            if (!itemStk.hasItemMeta()) {
+                return false;
+            }
             Integer itemCustomModel = itemMeta.getCustomModelData();
             return itemCustomModel.equals(customModelDataInt);
         }
@@ -501,15 +529,15 @@ public class ArmorStandEditorPlugin extends JavaPlugin{
 
         //Do we require a custom tool name?
         requireToolName = getConfig().getBoolean("requireToolName", false);
-        if(requireToolName){
+        if (requireToolName) {
             editToolName = getConfig().getString("toolName", null);
-            if(editToolName != null) editToolName = ChatColor.translateAlternateColorCodes('&', editToolName);
+            if (editToolName != null) editToolName = ChatColor.translateAlternateColorCodes('&', editToolName);
         }
 
         //Custom Model Data
         allowCustomModelData = getConfig().getBoolean("allowCustomModelData", false);
 
-        if(allowCustomModelData){
+        if (allowCustomModelData) {
             customModelDataInt = getConfig().getInt("customModelDataInt", Integer.MIN_VALUE);
         }
 
@@ -519,13 +547,13 @@ public class ArmorStandEditorPlugin extends JavaPlugin{
         //Is there NBT Required for the tool
         requireToolData = getConfig().getBoolean("requireToolData", false);
 
-        if(requireToolData) {
+        if (requireToolData) {
             editToolData = getConfig().getInt("toolData", Integer.MIN_VALUE);
         }
 
         requireToolLore = getConfig().getBoolean("requireToolLore", false);
 
-        if(requireToolLore) {
+        if (requireToolLore) {
             editToolLore = getConfig().getList("toolLore", null);
         }
 
@@ -551,9 +579,9 @@ public class ArmorStandEditorPlugin extends JavaPlugin{
         updateCheckerInterval = getConfig().getDouble("updateCheckerInterval", 24);
 
         //Run UpdateChecker - Reports out to Console on Startup ONLY!
-        if(!Scheduler.isFolia() && runTheUpdateChecker) {
+        if (!Scheduler.isFolia() && runTheUpdateChecker) {
 
-            if(opUpdateNotification){
+            if (opUpdateNotification) {
                 runUpdateCheckerWithOPNotifyOnJoinEnabled();
             } else {
                 runUpdateCheckerConsoleUpdateCheck();
@@ -562,12 +590,12 @@ public class ArmorStandEditorPlugin extends JavaPlugin{
         }
     }
 
-    public static ArmorStandEditorPlugin instance(){
+    public static ArmorStandEditorPlugin instance() {
         return instance;
     }
 
     //Metrics/bStats Support
-    private void getMetrics(){
+    private void getMetrics() {
 
         Metrics metrics = new Metrics(this, PLUGIN_ID);
 
@@ -603,17 +631,17 @@ public class ArmorStandEditorPlugin extends JavaPlugin{
                 map.put("Japanese", entry);
             } else if (languageUsed.startsWith("pl")) {
                 map.put("Polish", entry);
-            }else if(languageUsed.startsWith("ru")){ //See PR# 41 by KPidS
+            } else if (languageUsed.startsWith("ru")) { //See PR# 41 by KPidS
                 map.put("Russian", entry);
-            }else if(languageUsed.startsWith("ro")){
+            } else if (languageUsed.startsWith("ro")) {
                 map.put("Romanian", entry);
-            } else if(languageUsed.startsWith("uk")){
+            } else if (languageUsed.startsWith("uk")) {
                 map.put("Ukrainian", entry);
-            } else if(languageUsed.startsWith("zh")) {
+            } else if (languageUsed.startsWith("zh")) {
                 map.put("Chinese", entry);
-            } else if(languageUsed.startsWith("pt")) {
+            } else if (languageUsed.startsWith("pt")) {
                 map.put("Brazilian", entry);
-            } else{
+            } else {
                 map.put("English", entry);
             }
             return map;
@@ -635,7 +663,7 @@ public class ArmorStandEditorPlugin extends JavaPlugin{
     }
 
     public NamespacedKey getIconKey() {
-        if(iconKey == null) iconKey = new NamespacedKey(this, "command_icon");
+        if (iconKey == null) iconKey = new NamespacedKey(this, "command_icon");
         return iconKey;
     }
 

--- a/src/main/java/io/github/rypofalem/armorstandeditor/ArmorStandEditorPlugin.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/ArmorStandEditorPlugin.java
@@ -79,6 +79,7 @@ public class ArmorStandEditorPlugin extends JavaPlugin {
     String editToolName = null;
     boolean requireToolLore = false;
     List<?> editToolLore = null;
+    List<?> allowedWorldList = null;
     boolean allowCustomModelData = false;
     Integer customModelDataInt = Integer.MIN_VALUE;
 
@@ -225,6 +226,7 @@ public class ArmorStandEditorPlugin extends JavaPlugin {
             editToolLore = getConfig().getList("toolLore", null);
         }
 
+        allowedWorldList = getConfig().getList("allowed-worlds", null);
 
         //Require Sneaking - Wolfst0rm/ArmorStandEditor#17
         requireSneaking = getConfig().getBoolean("requireSneaking", false);
@@ -556,6 +558,8 @@ public class ArmorStandEditorPlugin extends JavaPlugin {
         if (requireToolLore) {
             editToolLore = getConfig().getList("toolLore", null);
         }
+
+        allowedWorldList = getConfig().getList("allowed-worlds", null);
 
         //Require Sneaking - Wolfst0rm/ArmorStandEditor#17
         requireSneaking = getConfig().getBoolean("requireSneaking", false);

--- a/src/main/java/io/github/rypofalem/armorstandeditor/ArmorStandEditorPlugin.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/ArmorStandEditorPlugin.java
@@ -19,12 +19,9 @@
 
 package io.github.rypofalem.armorstandeditor;
 
-import com.jeff_media.updatechecker.UpdateCheckSource;
-import com.jeff_media.updatechecker.UpdateChecker;
-import com.jeff_media.updatechecker.UserAgentBuilder;
-
-import io.github.rypofalem.armorstandeditor.Metrics.*;
 import io.github.rypofalem.armorstandeditor.language.Language;
+import com.jeff_media.updatechecker.*;
+import io.github.rypofalem.armorstandeditor.Metrics.*;
 
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -43,7 +40,7 @@ import java.io.File;
 import java.util.*;
 import java.util.logging.Level;
 
-public class ArmorStandEditorPlugin extends JavaPlugin {
+public class ArmorStandEditorPlugin extends JavaPlugin{
 
     //!!! DO NOT REMOVE THESE UNDER ANY CIRCUMSTANCES - Required for BStats and UpdateChecker !!!
     public static final int SPIGOT_RESOURCE_ID = 94503;  //Used for Update Checker
@@ -52,7 +49,7 @@ public class ArmorStandEditorPlugin extends JavaPlugin {
     private NamespacedKey iconKey;
     private static ArmorStandEditorPlugin instance;
     private Language lang;
-
+    
     //Server Version Detection: Paper or Spigot and Invalid NMS Version
     String nmsVersion;
     String languageFolderLocation = "lang/";
@@ -64,7 +61,7 @@ public class ArmorStandEditorPlugin extends JavaPlugin {
     static final String SEPARATOR_FIELD = "================================";
 
     public PlayerEditorManager editorManager;
-
+    
     //Output for Updates
     boolean opUpdateNotification = false;
     boolean runTheUpdateChecker = false;
@@ -79,14 +76,13 @@ public class ArmorStandEditorPlugin extends JavaPlugin {
     String editToolName = null;
     boolean requireToolLore = false;
     List<?> editToolLore = null;
-    List<?> allowedWorldList = null;
     boolean allowCustomModelData = false;
     Integer customModelDataInt = Integer.MIN_VALUE;
-
+    
     //GUI Settings
     boolean requireSneaking = false;
     boolean sendToActionBar = true;
-
+    
     //Armor Stand Specific Settings
     double coarseRot;
     double fineRot;
@@ -105,7 +101,7 @@ public class ArmorStandEditorPlugin extends JavaPlugin {
 
     private static ArmorStandEditorPlugin plugin;
 
-    public ArmorStandEditorPlugin() {
+    public ArmorStandEditorPlugin(){
         instance = this;
     }
 
@@ -124,7 +120,7 @@ public class ArmorStandEditorPlugin extends JavaPlugin {
 
         // Check if the Minecraft version is supported
         if (nmsVersion.compareTo("v1_17") < 0) {
-            getLogger().log(Level.WARNING, warningMCVer + "{0}", nmsVersion);
+            getLogger().log(Level.WARNING,warningMCVer + "{0}",nmsVersion);
             getLogger().warning("ArmorStandEditor is not compatible with this version of Minecraft. Please update to at least version 1.17. Loading failed.");
             getServer().getPluginManager().disablePlugin(this);
             getLogger().info(SEPARATOR_FIELD);
@@ -133,11 +129,11 @@ public class ArmorStandEditorPlugin extends JavaPlugin {
 
         //Also Warn People to Update if using nmsVersion lower than latest
         if (nmsVersion.compareTo("v1_20") < 0) {
-            getLogger().log(Level.WARNING, warningMCVer + "{0}", nmsVersion);
+            getLogger().log(Level.WARNING,warningMCVer + "{0}",nmsVersion);
             getLogger().warning("ArmorStandEditor is compatible with this version of Minecraft, but it is not the latest supported version.");
             getLogger().warning("Loading continuing, but please consider updating to the latest version.");
         } else {
-            getLogger().log(Level.INFO, warningMCVer + "{0}", nmsVersion);
+            getLogger().log(Level.INFO,warningMCVer + "{0}",nmsVersion);
             getLogger().info("ArmorStandEditor is compatible with this version of Minecraft. Loading continuing.");
         }
         //Spigot Check
@@ -145,16 +141,16 @@ public class ArmorStandEditorPlugin extends JavaPlugin {
         hasPaper = getHasPaper();
 
         //If Paper and Spigot are both FALSE - Disable the plugin
-        if (!hasPaper && !hasSpigot) {
+        if (!hasPaper && !hasSpigot){
             getLogger().severe("This plugin requires either Paper, Spigot or one of its forks to run. This is not an error, please do not report this!");
             getServer().getPluginManager().disablePlugin(this);
             getLogger().info(SEPARATOR_FIELD);
             return;
         } else {
             if (hasSpigot) {
-                getLogger().log(Level.INFO, "SpigotMC: {0}", hasSpigot);
+                getLogger().log(Level.INFO,"SpigotMC: {0}",hasSpigot);
             } else {
-                getLogger().log(Level.INFO, "PaperMC: {0}", hasPaper);
+                getLogger().log(Level.INFO,"PaperMC: {0}",hasPaper);
             }
         }
 
@@ -195,18 +191,18 @@ public class ArmorStandEditorPlugin extends JavaPlugin {
             getServer().getPluginManager().disablePlugin(this);
             return;
         }
-
+        
         //Do we require a custom tool name?
         requireToolName = getConfig().getBoolean("requireToolName", false);
-        if (requireToolName) {
+        if(requireToolName){
             editToolName = getConfig().getString("toolName", null);
-            if (editToolName != null) editToolName = ChatColor.translateAlternateColorCodes('&', editToolName);
+            if(editToolName != null) editToolName = ChatColor.translateAlternateColorCodes('&', editToolName);
         }
 
         //Custom Model Data
         allowCustomModelData = getConfig().getBoolean("allowCustomModelData", false);
 
-        if (allowCustomModelData) {
+        if(allowCustomModelData){
             customModelDataInt = getConfig().getInt("customModelDataInt", Integer.MIN_VALUE);
         }
 
@@ -216,17 +212,16 @@ public class ArmorStandEditorPlugin extends JavaPlugin {
         //Is there NBT Required for the tool
         requireToolData = getConfig().getBoolean("requireToolData", false);
 
-        if (requireToolData) {
+        if(requireToolData) {
             editToolData = getConfig().getInt("toolData", Integer.MIN_VALUE);
         }
 
         requireToolLore = getConfig().getBoolean("requireToolLore", false);
 
-        if (requireToolLore) {
+        if(requireToolLore) {
             editToolLore = getConfig().getList("toolLore", null);
         }
 
-        allowedWorldList = getConfig().getList("allowed-worlds", null);
 
         //Require Sneaking - Wolfst0rm/ArmorStandEditor#17
         requireSneaking = getConfig().getBoolean("requireSneaking", false);
@@ -251,9 +246,9 @@ public class ArmorStandEditorPlugin extends JavaPlugin {
         adminOnlyNotifications = getConfig().getBoolean("adminOnlyNotifications", true);
 
         //Run UpdateChecker - Reports out to Console on Startup ONLY!
-        if (!Scheduler.isFolia() && runTheUpdateChecker) {
+        if(!Scheduler.isFolia() && runTheUpdateChecker) {
 
-            if (opUpdateNotification) {
+            if(opUpdateNotification){
                 runUpdateCheckerWithOPNotifyOnJoinEnabled();
             } else {
                 runUpdateCheckerConsoleUpdateCheck();
@@ -285,12 +280,12 @@ public class ArmorStandEditorPlugin extends JavaPlugin {
             getLogger().info("Update Checker does not work on Development Builds.");
         } else {
             new UpdateChecker(this, UpdateCheckSource.SPIGET, "" + SPIGOT_RESOURCE_ID + "")
-                .setDownloadLink("https://www.spigotmc.org/resources/armorstandeditor-reborn.94503/")
-                .setChangelogLink("https://www.spigotmc.org/resources/armorstandeditor-reborn.94503/history")
-                .setColoredConsoleOutput(true)
-                .setUserAgent(new UserAgentBuilder().addPluginNameAndVersion().addServerVersion())
-                .checkEveryXHours(updateCheckerInterval)
-                .checkNow();
+                    .setDownloadLink("https://www.spigotmc.org/resources/armorstandeditor-reborn.94503/")
+                    .setChangelogLink("https://www.spigotmc.org/resources/armorstandeditor-reborn.94503/history")
+                    .setColoredConsoleOutput(true)
+                    .setUserAgent(new UserAgentBuilder().addPluginNameAndVersion().addServerVersion())
+                    .checkEveryXHours(updateCheckerInterval)
+                    .checkNow();
         }
     }
 
@@ -304,13 +299,13 @@ public class ArmorStandEditorPlugin extends JavaPlugin {
             getLogger().info("Update Checker does not work on Development Builds.");
         } else {
             new UpdateChecker(this, UpdateCheckSource.SPIGET, "" + SPIGOT_RESOURCE_ID + "")
-                .setDownloadLink("https://www.spigotmc.org/resources/armorstandeditor-reborn.94503/")
-                .setChangelogLink("https://www.spigotmc.org/resources/armorstandeditor-reborn.94503/history")
-                .setColoredConsoleOutput(true)
-                .setNotifyOpsOnJoin(true)
-                .setUserAgent(new UserAgentBuilder().addPluginNameAndVersion().addServerVersion())
-                .checkEveryXHours(updateCheckerInterval)
-                .checkNow();
+                    .setDownloadLink("https://www.spigotmc.org/resources/armorstandeditor-reborn.94503/")
+                    .setChangelogLink("https://www.spigotmc.org/resources/armorstandeditor-reborn.94503/history")
+                    .setColoredConsoleOutput(true)
+                    .setNotifyOpsOnJoin(true)
+                    .setUserAgent(new UserAgentBuilder().addPluginNameAndVersion().addServerVersion())
+                    .checkEveryXHours(updateCheckerInterval)
+                    .checkNow();
         }
     }
 
@@ -331,23 +326,23 @@ public class ArmorStandEditorPlugin extends JavaPlugin {
         getLogger().info("Removing Scoreboards required for Glowing Effects");
 
         team = scoreboard.getTeam(lockedTeam);
-        if (team != null) { //Basic Sanity Check to ensure that the team is there
+        if(team != null) { //Basic Sanity Check to ensure that the team is there
             team.unregister();
-        } else {
+        } else{
             getLogger().severe("Team Already Appears to be removed. Please do not do this manually!");
         }
     }
 
     private void updateConfig(String folder, String config) {
-        if (!new File(getDataFolder() + File.separator + folder + config).exists()) {
+        if(!new File(getDataFolder() + File.separator + folder + config).exists()){
             saveResource(folder  + config, false);
         }
     }
 
     @Override
-    public void onDisable() {
-        for (Player player : Bukkit.getServer().getOnlinePlayers()) {
-            if (player.getOpenInventory().getTopInventory().getHolder() == editorManager.getMenuHolder()) player.closeInventory();
+    public void onDisable(){
+        for(Player player : Bukkit.getServer().getOnlinePlayers()){
+            if(player.getOpenInventory().getTopInventory().getHolder() == editorManager.getMenuHolder()) player.closeInventory();
         }
 
         if (!Scheduler.isFolia()) {
@@ -356,46 +351,45 @@ public class ArmorStandEditorPlugin extends JavaPlugin {
         }
     }
 
-    public String getNmsVersion() {
-        return this.getServer().getClass().getPackage().getName().replace(".", ",").split(",")[3];
+    public String getNmsVersion(){
+        return this.getServer().getClass().getPackage().getName().replace(".",",").split(",")[3];
     }
 
-    public boolean getHasSpigot() {
+    public boolean getHasSpigot(){
         try {
             Class.forName("org.spigotmc.SpigotConfig");
             nmsVersionNotLatest = "SpigotMC ASAP.";
             return true;
-        } catch (ClassNotFoundException e) {
+        } catch (ClassNotFoundException e){
             nmsVersionNotLatest = "";
             return false;
         }
     }
 
-    public boolean getHasPaper() {
+    public boolean getHasPaper(){
         try {
             Class.forName("com.destroystokyo.paper.PaperConfig");
             nmsVersionNotLatest = "SpigotMC ASAP.";
             return true;
-        } catch (ClassNotFoundException e) {
+        } catch (ClassNotFoundException e){
             nmsVersionNotLatest = "";
             return false;
         }
     }
 
 
-    public String getArmorStandEditorVersion() {
-        return getConfig().getString("version");
-    }
 
-    public boolean getArmorStandVisibility() {
+    public String getArmorStandEditorVersion(){ return getConfig().getString("version"); }
+
+    public boolean getArmorStandVisibility(){
         return getConfig().getBoolean("armorStandVisibility");
     }
 
-    public boolean getItemFrameVisibility() {
+    public boolean getItemFrameVisibility(){
         return getConfig().getBoolean("invisibleItemFrames");
     }
 
-    public Language getLang() {
+    public Language getLang(){
         return lang;
     }
 
@@ -411,86 +405,62 @@ public class ArmorStandEditorPlugin extends JavaPlugin {
         return this.getConfig().getBoolean("runTheUpdateChecker");
     }
 
-    public Integer getCustomModelDataInt() {
-        return this.getConfig().getInt("customModelDataInt");
-    }
+    public Integer getCustomModelDataInt() { return this.getConfig().getInt("customModelDataInt"); }
 
     //New in 1.20-43: Allow the ability to get a player head from a command - ENABLED VIA CONFIG ONLY!
-    public boolean getAllowedToRetrievePlayerHead() {
-        return this.getConfig().getBoolean("allowedToRetrievePlayerHead");
-    }
+    public boolean getAllowedToRetrievePlayerHead() { return this.getConfig().getBoolean("allowedToRetrievePlayerHead"); }
 
-    public boolean getAdminOnlyNotifications() {
-        return this.getConfig().getBoolean("adminOnlyNotifications");
-    }
+    public boolean getAdminOnlyNotifications() { return this.getConfig().getBoolean("adminOnlyNotifications"); }
 
-    public boolean isEditTool(ItemStack itemStk) {
-        if (itemStk == null) {
-            return false;
-        }
-        if (editTool != itemStk.getType()) {
-            return false;
-        }
+    public boolean isEditTool(ItemStack itemStk){
+        if (itemStk == null) { return false; }
+        if (editTool != itemStk.getType()) { return false; }
 
         ItemMeta itemMeta = itemStk.getItemMeta();
-        if (itemMeta == null) return false;
+        if(itemMeta == null) return false;
 
         //FIX: Depreciated Stack for getDurability
-        if (requireToolData) {
+        if (requireToolData){
             Damageable d1 = (Damageable) itemMeta; //Get the Damageable Options for itemStk
             if (d1 != null) { //We do this to prevent NullPointers
-                if (d1.getDamage() != (short) editToolData) {
-                    return false;
-                }
+                if (d1.getDamage() != (short) editToolData) { return false; }
             }
         }
 
-        if (requireToolName && editToolName != null) {
-            if (!itemStk.hasItemMeta()) {
-                return false;
-            }
+        if(requireToolName && editToolName != null){
+            if(!itemStk.hasItemMeta()) { return false; }
 
             //Get the name of the Edit Tool - If Null, return false
             String itemName = itemMeta.getDisplayName();
 
             //If the name of the Edit Tool is not the Name specified in Config then Return false
-            if (!itemName.equals(editToolName)) {
-                return false;
-            }
+            if(!itemName.equals(editToolName)) { return false; }
 
         }
 
-        if (requireToolLore && editToolLore != null) {
+        if(requireToolLore && editToolLore != null){
 
             //If the ItemStack does not have Metadata then we return false
-            if (!itemStk.hasItemMeta()) {
-                return false;
-            }
+            if(!itemStk.hasItemMeta()) { return false; }
 
             //Get the lore of the Item and if it is null - Return False
             List<String> itemLore = itemMeta.getLore();
 
             //If the Item does not have Lore - Return False
             boolean hasTheItemLore = itemMeta.hasLore();
-            if (!hasTheItemLore) {
-                return false;
-            }
+            if (!hasTheItemLore)  { return false; }
 
             //Get the localised ListString of editToolLore
             List<String> listStringOfEditToolLore = (List<String>) editToolLore;
 
             //Return False if itemLore on the item does not match what we expect in the config.
-            if (!itemLore.equals(listStringOfEditToolLore)) {
-                return false;
-            }
+            if(!itemLore.equals(listStringOfEditToolLore)) { return false; }
 
         }
 
         if (allowCustomModelData && customModelDataInt != null) {
             //If the ItemStack does not have Metadata then we return false
-            if (!itemStk.hasItemMeta()) {
-                return false;
-            }
+            if(!itemStk.hasItemMeta()) { return false; }
             Integer itemCustomModel = itemMeta.getCustomModelData();
             return itemCustomModel.equals(customModelDataInt);
         }
@@ -531,15 +501,15 @@ public class ArmorStandEditorPlugin extends JavaPlugin {
 
         //Do we require a custom tool name?
         requireToolName = getConfig().getBoolean("requireToolName", false);
-        if (requireToolName) {
+        if(requireToolName){
             editToolName = getConfig().getString("toolName", null);
-            if (editToolName != null) editToolName = ChatColor.translateAlternateColorCodes('&', editToolName);
+            if(editToolName != null) editToolName = ChatColor.translateAlternateColorCodes('&', editToolName);
         }
 
         //Custom Model Data
         allowCustomModelData = getConfig().getBoolean("allowCustomModelData", false);
 
-        if (allowCustomModelData) {
+        if(allowCustomModelData){
             customModelDataInt = getConfig().getInt("customModelDataInt", Integer.MIN_VALUE);
         }
 
@@ -549,17 +519,15 @@ public class ArmorStandEditorPlugin extends JavaPlugin {
         //Is there NBT Required for the tool
         requireToolData = getConfig().getBoolean("requireToolData", false);
 
-        if (requireToolData) {
+        if(requireToolData) {
             editToolData = getConfig().getInt("toolData", Integer.MIN_VALUE);
         }
 
         requireToolLore = getConfig().getBoolean("requireToolLore", false);
 
-        if (requireToolLore) {
+        if(requireToolLore) {
             editToolLore = getConfig().getList("toolLore", null);
         }
-
-        allowedWorldList = getConfig().getList("allowed-worlds", null);
 
         //Require Sneaking - Wolfst0rm/ArmorStandEditor#17
         requireSneaking = getConfig().getBoolean("requireSneaking", false);
@@ -583,9 +551,9 @@ public class ArmorStandEditorPlugin extends JavaPlugin {
         updateCheckerInterval = getConfig().getDouble("updateCheckerInterval", 24);
 
         //Run UpdateChecker - Reports out to Console on Startup ONLY!
-        if (!Scheduler.isFolia() && runTheUpdateChecker) {
+        if(!Scheduler.isFolia() && runTheUpdateChecker) {
 
-            if (opUpdateNotification) {
+            if(opUpdateNotification){
                 runUpdateCheckerWithOPNotifyOnJoinEnabled();
             } else {
                 runUpdateCheckerConsoleUpdateCheck();
@@ -594,12 +562,12 @@ public class ArmorStandEditorPlugin extends JavaPlugin {
         }
     }
 
-    public static ArmorStandEditorPlugin instance() {
+    public static ArmorStandEditorPlugin instance(){
         return instance;
     }
 
     //Metrics/bStats Support
-    private void getMetrics() {
+    private void getMetrics(){
 
         Metrics metrics = new Metrics(this, PLUGIN_ID);
 
@@ -635,17 +603,17 @@ public class ArmorStandEditorPlugin extends JavaPlugin {
                 map.put("Japanese", entry);
             } else if (languageUsed.startsWith("pl")) {
                 map.put("Polish", entry);
-            } else if (languageUsed.startsWith("ru")) { //See PR# 41 by KPidS
+            }else if(languageUsed.startsWith("ru")){ //See PR# 41 by KPidS
                 map.put("Russian", entry);
-            } else if (languageUsed.startsWith("ro")) {
+            }else if(languageUsed.startsWith("ro")){
                 map.put("Romanian", entry);
-            } else if (languageUsed.startsWith("uk")) {
+            } else if(languageUsed.startsWith("uk")){
                 map.put("Ukrainian", entry);
-            } else if (languageUsed.startsWith("zh")) {
+            } else if(languageUsed.startsWith("zh")) {
                 map.put("Chinese", entry);
-            } else if (languageUsed.startsWith("pt")) {
+            } else if(languageUsed.startsWith("pt")) {
                 map.put("Brazilian", entry);
-            } else {
+            } else{
                 map.put("English", entry);
             }
             return map;
@@ -667,7 +635,7 @@ public class ArmorStandEditorPlugin extends JavaPlugin {
     }
 
     public NamespacedKey getIconKey() {
-        if (iconKey == null) iconKey = new NamespacedKey(this, "command_icon");
+        if(iconKey == null) iconKey = new NamespacedKey(this, "command_icon");
         return iconKey;
     }
 

--- a/src/main/java/io/github/rypofalem/armorstandeditor/ArmorStandEditorPlugin.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/ArmorStandEditorPlugin.java
@@ -119,9 +119,9 @@ public class ArmorStandEditorPlugin extends JavaPlugin{
         getLogger().info("Plugin Version: " + pdfFile.getVersion());
 
         // Check if the Minecraft version is supported
-        if (nmsVersion.compareTo("v1_13") < 0) {
+        if (nmsVersion.compareTo("v1_17") < 0) {
             getLogger().log(Level.WARNING,warningMCVer + "{0}",nmsVersion);
-            getLogger().warning("ArmorStandEditor is not compatible with this version of Minecraft. Please update to at least version 1.13. Loading failed.");
+            getLogger().warning("ArmorStandEditor is not compatible with this version of Minecraft. Please update to at least version 1.17. Loading failed.");
             getServer().getPluginManager().disablePlugin(this);
             getLogger().info(SEPARATOR_FIELD);
             return;

--- a/src/main/java/io/github/rypofalem/armorstandeditor/CommandEx.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/CommandEx.java
@@ -596,7 +596,7 @@ public class CommandEx implements CommandExecutor, TabCompleter {
             "Size", "Copy", "Paste", "Head", "Body", "LeftArm",
             "RightArm", "LeftLeg", "RightLeg", "Placement",
             "DisableSlots", "Rotate", "Equipment", "Reset",
-            "ItemFrame", "ItemFrameGlow"
+            "ItemFrame", "ItemFrameGlow", "Vulnerability", "ArmorStandGlow"
         );
     }
 

--- a/src/main/java/io/github/rypofalem/armorstandeditor/CommandEx.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/CommandEx.java
@@ -72,6 +72,7 @@ public class CommandEx implements CommandExecutor, TabCompleter {
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+
         if (sender instanceof ConsoleCommandSender) { //Fix to Support #267
             if (args.length == 0) {
                 sender.sendMessage(VERSION);
@@ -305,8 +306,8 @@ public class CommandEx implements CommandExecutor, TabCompleter {
         if (args.length > 1) {
             for (EditMode mode : EditMode.values()) {
                 if (mode.toString().toLowerCase().contentEquals(args[1].toLowerCase())) {
-                    if (args[1].equals("invisible") && !checkPermission(player, "togglearmorstandvisibility", true)) return;
-                    if (args[1].equals("itemframe") && !checkPermission(player, "toggleitemframevisibility", true)) return;
+                    if (args[1].equals("invisible") && !(checkPermission(player, "togglearmorstandvisibility", true) || plugin.getArmorStandVisibility())) return;
+                    if (args[1].equals("itemframe") && !(checkPermission(player, "toggleitemframevisibility", true) || plugin.getItemFrameVisibility())) return;
                     plugin.editorManager.getPlayerEditor(player.getUniqueId()).setMode(mode);
                     return;
                 }
@@ -417,7 +418,7 @@ public class CommandEx implements CommandExecutor, TabCompleter {
                 boolean isSmall = as.isSmall();
                 boolean isLocked = plugin.scoreboard.getTeam(plugin.lockedTeam).hasEntry(as.getUniqueId().toString());
 
-                player.sendMessage(ChatColor.YELLOW + "--------- Armor Stand Statistics ---------");
+                player.sendMessage(ChatColor.YELLOW + "----------- Armor Stand Statistics -----------");
                 player.sendMessage(ChatColor.YELLOW + plugin.getLang().getMessage("stats"));
                 player.sendMessage(ChatColor.YELLOW + "Head: " + ChatColor.AQUA + headX + " / " + headY + " / " + headZ);
                 player.sendMessage(ChatColor.YELLOW + "Body: " + ChatColor.AQUA + bodyX + " / " + bodyY + " / " + bodyZ);
@@ -429,9 +430,9 @@ public class CommandEx implements CommandExecutor, TabCompleter {
                 player.sendMessage(ChatColor.YELLOW + "Is Visible: " + ChatColor.AQUA + isVisible + ". " + ChatColor.YELLOW + "Arms Visible: " + ChatColor.AQUA + armsVisible + ". " + ChatColor.YELLOW + "Base Plate Visible: "+ ChatColor.AQUA + basePlateVisible);
                 player.sendMessage(ChatColor.YELLOW + "Is Vulnerable: " + ChatColor.AQUA + isVulnerable + ". " + ChatColor.YELLOW + "Affected by Gravity: " + ChatColor.AQUA + hasGravity);
                 player.sendMessage(ChatColor.YELLOW + "Is Small: " + ChatColor.AQUA + isSmall + ". " + ChatColor.YELLOW + "Is Locked: " + ChatColor.AQUA + isLocked);
-                player.sendMessage(ChatColor.YELLOW + "---------------------------------------------");
+                player.sendMessage(ChatColor.YELLOW + "----------------------------------------------");
             } else{
-                player.sendMessage("nopermoption", "warn", "stats");
+                player.sendMessage(plugin.getLang().getMessage("norangeforstats", "warn"));
             }
         }
     }

--- a/src/main/java/io/github/rypofalem/armorstandeditor/CommandEx.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/CommandEx.java
@@ -37,6 +37,8 @@ import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.command.*;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
@@ -61,6 +63,7 @@ public class CommandEx implements CommandExecutor, TabCompleter {
     final String RELOAD = ChatColor.YELLOW + "/ase reload";
     final String GIVECUSTOMMODEL = ChatColor.YELLOW + "/ase give";
     final String GIVEPLAYERHEAD = ChatColor.YELLOW + "/ase playerhead <name>";
+    final String GETARMORSTATS = ChatColor.YELLOW + "/ase stats";
     Gson gson = new Gson();
 
     public CommandEx(ArmorStandEditorPlugin armorStandEditorPlugin) {
@@ -105,6 +108,7 @@ public class CommandEx implements CommandExecutor, TabCompleter {
                 player.sendMessage(RELOAD);
                 player.sendMessage(GIVECUSTOMMODEL);
                 player.sendMessage(GIVEPLAYERHEAD);
+                player.sendMessage(GETARMORSTATS);
                 return true;
             }
             switch (args[0].toLowerCase()) {
@@ -118,6 +122,7 @@ public class CommandEx implements CommandExecutor, TabCompleter {
                 case "give" -> commandGive(player);
                 case "playerhead" -> commandGivePlayerHead(player, args);
                 case "reload" -> commandReload(player);
+                case "stats" -> commandStats(player);
                 default -> {
                     sender.sendMessage(LISTMODE);
                     sender.sendMessage(LISTAXIS);
@@ -129,12 +134,12 @@ public class CommandEx implements CommandExecutor, TabCompleter {
                     sender.sendMessage(RELOAD);
                     sender.sendMessage(GIVECUSTOMMODEL);
                     sender.sendMessage(GIVEPLAYERHEAD);
+                    sender.sendMessage(GETARMORSTATS);
                 }
             }
             return true;
         }
     }
-
 
     // Implemented to fix:
     // https://github.com/Wolfieheart/ArmorStandEditor-Issues/issues/35 &
@@ -370,6 +375,68 @@ public class CommandEx implements CommandExecutor, TabCompleter {
         sender.sendMessage(plugin.getLang().getMessage("reloaded", "info"));
     }
 
+    private void commandStats(Player player) {
+        if(!getPermissionStats(player)) return;
+        for(Entity e : player.getNearbyEntities(1,1,1)){
+            if(e instanceof ArmorStand as){
+
+                //Calculation TIME - Might move this out later, but is OK here for now
+                double headX = as.getHeadPose().getX(); headX = Math.toDegrees(headX); headX = Math.rint(headX);
+                double headY = as.getHeadPose().getY(); headY = Math.toDegrees(headY); headY = Math.rint(headY);
+                double headZ = as.getHeadPose().getZ(); headZ = Math.toDegrees(headZ); headZ = Math.rint(headZ);
+
+                double bodyX = as.getBodyPose().getX(); bodyX = Math.toDegrees(bodyX); bodyX = Math.rint(bodyX);
+                double bodyY = as.getBodyPose().getY(); bodyY = Math.toDegrees(bodyY); bodyY = Math.rint(bodyY);
+                double bodyZ = as.getBodyPose().getZ(); bodyZ = Math.toDegrees(bodyZ); bodyZ = Math.rint(bodyZ);
+
+                double rightArmX = as.getRightArmPose().getX(); rightArmX = Math.toDegrees(rightArmX); rightArmX = Math.rint(rightArmX);
+                double rightArmY = as.getRightArmPose().getY(); rightArmY = Math.toDegrees(rightArmY); rightArmY = Math.rint(rightArmY);
+                double rightArmZ = as.getRightArmPose().getZ(); rightArmZ = Math.toDegrees(rightArmZ); rightArmZ = Math.rint(rightArmZ);
+
+                double leftArmX = as.getLeftArmPose().getX(); leftArmX = Math.toDegrees(leftArmX); leftArmX = Math.rint(leftArmX);
+                double leftArmY = as.getLeftArmPose().getY(); leftArmY = Math.toDegrees(leftArmY); leftArmY = Math.rint(leftArmY);
+                double leftArmZ = as.getLeftArmPose().getZ(); leftArmZ = Math.toDegrees(leftArmZ); leftArmZ = Math.rint(leftArmZ);
+
+                double rightLegX = as.getRightLegPose().getX(); rightLegX = Math.toDegrees(rightLegX); rightLegX = Math.rint(rightLegX);
+                double rightLegY = as.getRightLegPose().getY(); rightLegY = Math.toDegrees(rightLegY); rightLegY = Math.rint(rightLegY);
+                double rightLegZ = as.getRightLegPose().getZ(); rightLegZ = Math.toDegrees(rightLegZ); rightArmX = Math.rint(rightLegZ);
+
+                double leftLegX = as.getLeftLegPose().getX(); leftLegX = Math.toDegrees(leftLegX); leftLegX = Math.rint(leftLegX);
+                double leftLegY = as.getLeftLegPose().getY(); leftLegY = Math.toDegrees(leftLegY); leftLegY = Math.rint(leftLegY);
+                double leftLegZ = as.getLeftLegPose().getZ(); leftLegZ = Math.toDegrees(leftLegZ); leftLegZ = Math.rint(leftLegZ);
+
+                float locationX = (float) as.getLocation().getX();
+                float locationY = (float) as.getLocation().getY();
+                float locationZ = (float) as.getLocation().getZ();
+
+                boolean isVisible = as.isVisible();
+                boolean armsVisible = as.hasArms();
+                boolean basePlateVisible = as.hasBasePlate();
+                boolean isVulnerable = as.isInvulnerable();
+                boolean hasGravity = as.hasGravity();
+                boolean isSmall = as.isSmall();
+                boolean isLocked = plugin.scoreboard.getTeam(plugin.lockedTeam).hasEntry(as.getUniqueId().toString());
+
+                player.sendMessage(ChatColor.YELLOW + "--------- Armor Stand Statistics ---------");
+                player.sendMessage(ChatColor.YELLOW + plugin.getLang().getMessage("stats"));
+                player.sendMessage(ChatColor.YELLOW + "Head: " + ChatColor.AQUA + headX + " / " + headY + " / " + headZ);
+                player.sendMessage(ChatColor.YELLOW + "Body: " + ChatColor.AQUA + bodyX + " / " + bodyY + " / " + bodyZ);
+                player.sendMessage(ChatColor.YELLOW + "Right Arm: " + ChatColor.AQUA + rightArmX + " / " + rightArmY + " / " + rightArmZ);
+                player.sendMessage(ChatColor.YELLOW + "Left Arm: " + ChatColor.AQUA + leftArmX + " / " + leftArmY + " / " + leftArmZ);
+                player.sendMessage(ChatColor.YELLOW + "Right Leg: " + ChatColor.AQUA + rightLegX + " / " + rightLegY + " / " + rightLegZ);
+                player.sendMessage(ChatColor.YELLOW + "Left Leg: " + ChatColor.AQUA + leftLegX + " / " + leftLegY + " / " + leftLegZ);
+                player.sendMessage(ChatColor.YELLOW + "Coordinates: " + ChatColor.AQUA + " x: " + locationX + " / y: " + locationY + " / z: " + locationZ);
+                player.sendMessage(ChatColor.YELLOW + "Is Visible: " + ChatColor.AQUA + isVisible + ". " + ChatColor.YELLOW + "Arms Visible: " + ChatColor.AQUA + armsVisible + ". " + ChatColor.YELLOW + "Base Plate Visible: "+ ChatColor.AQUA + basePlateVisible);
+                player.sendMessage(ChatColor.YELLOW + "Is Vulnerable: " + ChatColor.AQUA + isVulnerable + ". " + ChatColor.YELLOW + "Affected by Gravity: " + ChatColor.AQUA + hasGravity);
+                player.sendMessage(ChatColor.YELLOW + "Is Small: " + ChatColor.AQUA + isSmall + ". " + ChatColor.YELLOW + "Is Locked: " + ChatColor.AQUA + isLocked);
+                player.sendMessage(ChatColor.YELLOW + "---------------------------------------------");
+            } else{
+                player.sendMessage("nopermoption", "warn", "stats");
+            }
+        }
+    }
+
+
     private boolean checkPermission(Player player, String permName, boolean sendMessageOnInvalidation) {
         if (permName.equalsIgnoreCase("paste")) {
             permName = "copy";
@@ -387,21 +454,20 @@ public class CommandEx implements CommandExecutor, TabCompleter {
     private boolean getPermissionBasic(Player player) {
         return checkPermission(player, "basic", false);
     }
-
     private boolean getPermissionGive(Player player) {
         return checkPermission(player, "give", false);
     }
-
     private boolean getPermissionUpdate(Player player) {
         return checkPermission(player, "update", false);
     }
-
     private boolean getPermissionReload(Player player) {
         return checkPermission(player, "reload", false);
     }
-
     private boolean getPermissionPlayerHead(Player player) {
         return checkPermission(player, "head", false);
+    }
+    private boolean getPermissionStats(Player player) {
+        return checkPermission(player, "stats", false);
     }
 
     //REFACTOR COMPLETION
@@ -432,6 +498,10 @@ public class CommandEx implements CommandExecutor, TabCompleter {
                 }
                 if (getPermissionPlayerHead(player) && plugin.getAllowedToRetrievePlayerHead()) {
                     argList.add("playerhead");
+                }
+
+                if (getPermissionStats(player)){
+                    argList.add("stats");
                 }
             }
 

--- a/src/main/java/io/github/rypofalem/armorstandeditor/CommandEx.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/CommandEx.java
@@ -63,24 +63,24 @@ public class CommandEx implements CommandExecutor, TabCompleter {
     final String GIVEPLAYERHEAD = ChatColor.YELLOW + "/ase playerhead <name>";
     Gson gson = new Gson();
 
-    public CommandEx( ArmorStandEditorPlugin armorStandEditorPlugin) {
+    public CommandEx(ArmorStandEditorPlugin armorStandEditorPlugin) {
         this.plugin = armorStandEditorPlugin;
     }
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
-        if(sender instanceof ConsoleCommandSender){ //Fix to Support #267
-            if(args.length == 0){
+        if (sender instanceof ConsoleCommandSender) { //Fix to Support #267
+            if (args.length == 0) {
                 sender.sendMessage(VERSION);
                 sender.sendMessage(HELP);
                 sender.sendMessage(RELOAD);
-            } else{
-                switch(args[0].toLowerCase()) {
+            } else {
+                switch (args[0].toLowerCase()) {
                     case "reload" -> commandReloadConsole(sender);
                     case "help", "?" -> commandHelpConsole(sender);
                     case "version" -> commandVersionConsole(sender);
                     default -> {
-                        sender.sendMessage(plugin.getLang().getMessage("noconsolecom","warn"));
+                        sender.sendMessage(plugin.getLang().getMessage("noconsolecom", "warn"));
                     }
                 }
                 return true;
@@ -88,7 +88,7 @@ public class CommandEx implements CommandExecutor, TabCompleter {
 
         }
 
-        if(sender instanceof Player player && !getPermissionBasic( player)){
+        if (sender instanceof Player player && !getPermissionBasic(player)) {
             sender.sendMessage(plugin.getLang().getMessage("noperm", "warn"));
             return true;
         } else {
@@ -149,20 +149,20 @@ public class CommandEx implements CommandExecutor, TabCompleter {
             stack.setItemMeta(meta);
             player.getInventory().addItem(stack);
             player.sendMessage(plugin.getLang().getMessage("give", "info"));
-        } else{
+        } else {
             player.sendMessage(plugin.getLang().getMessage("nogive", "warn"));
         }
     }
 
-    private void commandGivePlayerHead(Player player,String[] args) {
-          if(plugin.getAllowedToRetrievePlayerHead() && checkPermission(player, "head", true)){
+    private void commandGivePlayerHead(Player player, String[] args) {
+        if (plugin.getAllowedToRetrievePlayerHead() && checkPermission(player, "head", true)) {
 
-            if(args.length == 2){
+            if (args.length == 2) {
 
                 //Get the Player head Texture
                 String skinTexture = getPlayerHeadTexture(args[1]);
 
-                if(skinTexture == null){
+                if (skinTexture == null) {
                     player.sendMessage(plugin.getLang().getMessage("playerheaderror", "warn"));
                 }
 
@@ -198,16 +198,16 @@ public class CommandEx implements CommandExecutor, TabCompleter {
 
                 //Add the head to the Players Inventory + display PlayerHead Success Message
                 player.getInventory().addItem(playerHead);
-                player.sendMessage(plugin.getLang().getMessage("playerhead","info"));
+                player.sendMessage(plugin.getLang().getMessage("playerhead", "info"));
 
                 //Let Admins know this command has been ran
-                for(Player onlineList : Bukkit.getOnlinePlayers()){
-                    if(onlineList.hasPermission("asedit.permpack.admin") && plugin.getAdminOnlyNotifications()){
+                for (Player onlineList : Bukkit.getOnlinePlayers()) {
+                    if (onlineList.hasPermission("asedit.permpack.admin") && plugin.getAdminOnlyNotifications()) {
                         onlineList.sendMessage(ChatColor.YELLOW + "[ArmorStandEditor] " + player.getName() + "has just used the /ase playerhead command to get the head for " + args[1]);
                     }
                 }
             }
-        } else{
+        } else {
             player.sendMessage(plugin.getLang().getMessage("noplayerhead", "warn"));
         }
     }
@@ -251,7 +251,7 @@ public class CommandEx implements CommandExecutor, TabCompleter {
                     player.sendMessage(LISTSLOT);
                 }
 
-            } catch ( NumberFormatException nfe) {
+            } catch (NumberFormatException nfe) {
                 player.sendMessage(LISTSLOT);
             }
         }
@@ -264,7 +264,7 @@ public class CommandEx implements CommandExecutor, TabCompleter {
         }
 
         if (args.length > 1) {
-            for ( AdjustmentMode adj : AdjustmentMode.values()) {
+            for (AdjustmentMode adj : AdjustmentMode.values()) {
                 if (adj.toString().toLowerCase().contentEquals(args[1].toLowerCase())) {
                     plugin.editorManager.getPlayerEditor(player.getUniqueId()).setAdjMode(adj);
                     return;
@@ -274,14 +274,14 @@ public class CommandEx implements CommandExecutor, TabCompleter {
         }
     }
 
-    private void commandAxis( Player player,  String[] args) {
+    private void commandAxis(Player player, String[] args) {
         if (args.length <= 1) {
             player.sendMessage(plugin.getLang().getMessage("noaxiscom", "warn"));
             player.sendMessage(LISTAXIS);
         }
 
         if (args.length > 1) {
-            for ( Axis axis : Axis.values()) {
+            for (Axis axis : Axis.values()) {
                 if (axis.toString().toLowerCase().contentEquals(args[1].toLowerCase())) {
                     plugin.editorManager.getPlayerEditor(player.getUniqueId()).setAxis(axis);
                     return;
@@ -291,14 +291,14 @@ public class CommandEx implements CommandExecutor, TabCompleter {
         }
     }
 
-    private void commandMode( Player player,  String[] args) {
+    private void commandMode(Player player, String[] args) {
         if (args.length <= 1) {
             player.sendMessage(plugin.getLang().getMessage("nomodecom", "warn"));
             player.sendMessage(LISTMODE);
         }
 
         if (args.length > 1) {
-            for ( EditMode mode : EditMode.values()) {
+            for (EditMode mode : EditMode.values()) {
                 if (mode.toString().toLowerCase().contentEquals(args[1].toLowerCase())) {
                     if (args[1].equals("invisible") && !checkPermission(player, "togglearmorstandvisibility", true)) return;
                     if (args[1].equals("itemframe") && !checkPermission(player, "toggleitemframevisibility", true)) return;
@@ -354,13 +354,13 @@ public class CommandEx implements CommandExecutor, TabCompleter {
         player.sendMessage(ChatColor.YELLOW + "[ArmorStandEditor] Version: " + verString);
     }
 
-    private void commandVersionConsole(CommandSender sender){
+    private void commandVersionConsole(CommandSender sender) {
         String verString = plugin.getArmorStandEditorVersion();
         sender.sendMessage(ChatColor.YELLOW + "[ArmorStandEditor] Version: " + verString);
     }
 
-    private void commandReload(Player player){
-        if(!(getPermissionReload(player))) return;
+    private void commandReload(Player player) {
+        if (!(getPermissionReload(player))) return;
         plugin.performReload();
         player.sendMessage(plugin.getLang().getMessage("reloaded", ""));
     }
@@ -370,7 +370,7 @@ public class CommandEx implements CommandExecutor, TabCompleter {
         sender.sendMessage(plugin.getLang().getMessage("reloaded", "info"));
     }
 
-    private boolean checkPermission(Player player, String permName,  boolean sendMessageOnInvalidation) {
+    private boolean checkPermission(Player player, String permName, boolean sendMessageOnInvalidation) {
         if (permName.equalsIgnoreCase("paste")) {
             permName = "copy";
         }
@@ -388,9 +388,11 @@ public class CommandEx implements CommandExecutor, TabCompleter {
         return checkPermission(player, "basic", false);
     }
 
-    private boolean getPermissionGive(Player player) { return checkPermission(player, "give", false); }
+    private boolean getPermissionGive(Player player) {
+        return checkPermission(player, "give", false);
+    }
 
-    private boolean getPermissionUpdate(Player player){
+    private boolean getPermissionUpdate(Player player) {
         return checkPermission(player, "update", false);
     }
 
@@ -398,7 +400,9 @@ public class CommandEx implements CommandExecutor, TabCompleter {
         return checkPermission(player, "reload", false);
     }
 
-    private boolean getPermissionPlayerHead(Player player) { return checkPermission(player, "head", false); }
+    private boolean getPermissionPlayerHead(Player player) {
+        return checkPermission(player, "head", false);
+    }
 
     //REFACTOR COMPLETION
     @Override
@@ -417,16 +421,16 @@ public class CommandEx implements CommandExecutor, TabCompleter {
                 argList.add("?");
 
                 //Will Only work with permissions
-                if(getPermissionGive(player)){
+                if (getPermissionGive(player)) {
                     argList.add("give");
                 }
-                if(getPermissionUpdate(player)){
+                if (getPermissionUpdate(player)) {
                     argList.add("update");
                 }
-                if(getPermissionReload(player)){
+                if (getPermissionReload(player)) {
                     argList.add("reload");
                 }
-                if(getPermissionPlayerHead(player) && plugin.getAllowedToRetrievePlayerHead()){
+                if (getPermissionPlayerHead(player) && plugin.getAllowedToRetrievePlayerHead()) {
                     argList.add("playerhead");
                 }
             }
@@ -455,17 +459,17 @@ public class CommandEx implements CommandExecutor, TabCompleter {
 
     private boolean isCommandValid(String commandName) {
         return commandName.equalsIgnoreCase("ase") ||
-                commandName.equalsIgnoreCase("armorstandeditor") ||
-                commandName.equalsIgnoreCase("asedit");
+            commandName.equalsIgnoreCase("armorstandeditor") ||
+            commandName.equalsIgnoreCase("asedit");
     }
 
     private List<String> getModeOptions() {
         return List.of(
-                "None", "Invisible", "ShowArms", "Gravity", "BasePlate",
-                "Size", "Copy", "Paste", "Head", "Body", "LeftArm",
-                "RightArm", "LeftLeg", "RightLeg", "Placement",
-                "DisableSlots", "Rotate", "Equipment", "Reset",
-                "ItemFrame", "ItemFrameGlow"
+            "None", "Invisible", "ShowArms", "Gravity", "BasePlate",
+            "Size", "Copy", "Paste", "Head", "Body", "LeftArm",
+            "RightArm", "LeftLeg", "RightLeg", "Placement",
+            "DisableSlots", "Rotate", "Equipment", "Reset",
+            "ItemFrame", "ItemFrameGlow"
         );
     }
 

--- a/src/main/java/io/github/rypofalem/armorstandeditor/CommandEx.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/CommandEx.java
@@ -416,6 +416,7 @@ public class CommandEx implements CommandExecutor, TabCompleter {
                 boolean isVulnerable = as.isInvulnerable();
                 boolean hasGravity = as.hasGravity();
                 boolean isSmall = as.isSmall();
+                boolean isGlowing = as.isGlowing();
                 boolean isLocked = plugin.scoreboard.getTeam(plugin.lockedTeam).hasEntry(as.getUniqueId().toString());
 
                 player.sendMessage(ChatColor.YELLOW + "----------- Armor Stand Statistics -----------");
@@ -429,7 +430,7 @@ public class CommandEx implements CommandExecutor, TabCompleter {
                 player.sendMessage(ChatColor.YELLOW + "Coordinates: " + ChatColor.AQUA + " x: " + locationX + " / y: " + locationY + " / z: " + locationZ);
                 player.sendMessage(ChatColor.YELLOW + "Is Visible: " + ChatColor.AQUA + isVisible + ". " + ChatColor.YELLOW + "Arms Visible: " + ChatColor.AQUA + armsVisible + ". " + ChatColor.YELLOW + "Base Plate Visible: "+ ChatColor.AQUA + basePlateVisible);
                 player.sendMessage(ChatColor.YELLOW + "Is Vulnerable: " + ChatColor.AQUA + isVulnerable + ". " + ChatColor.YELLOW + "Affected by Gravity: " + ChatColor.AQUA + hasGravity);
-                player.sendMessage(ChatColor.YELLOW + "Is Small: " + ChatColor.AQUA + isSmall + ". " + ChatColor.YELLOW + "Is Locked: " + ChatColor.AQUA + isLocked);
+                player.sendMessage(ChatColor.YELLOW + "Is Small: " + ChatColor.AQUA + isSmall + ". " + ChatColor.YELLOW + "Is Glowing: " + ChatColor.AQUA + isGlowing + ". "  + ChatColor.YELLOW + "Is Locked: " + ChatColor.AQUA + isLocked);
                 player.sendMessage(ChatColor.YELLOW + "----------------------------------------------");
             } else{
                 player.sendMessage(plugin.getLang().getMessage("norangeforstats", "warn"));

--- a/src/main/java/io/github/rypofalem/armorstandeditor/CommandEx.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/CommandEx.java
@@ -63,24 +63,24 @@ public class CommandEx implements CommandExecutor, TabCompleter {
     final String GIVEPLAYERHEAD = ChatColor.YELLOW + "/ase playerhead <name>";
     Gson gson = new Gson();
 
-    public CommandEx(ArmorStandEditorPlugin armorStandEditorPlugin) {
+    public CommandEx( ArmorStandEditorPlugin armorStandEditorPlugin) {
         this.plugin = armorStandEditorPlugin;
     }
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
-        if (sender instanceof ConsoleCommandSender) { //Fix to Support #267
-            if (args.length == 0) {
+        if(sender instanceof ConsoleCommandSender){ //Fix to Support #267
+            if(args.length == 0){
                 sender.sendMessage(VERSION);
                 sender.sendMessage(HELP);
                 sender.sendMessage(RELOAD);
-            } else {
-                switch (args[0].toLowerCase()) {
+            } else{
+                switch(args[0].toLowerCase()) {
                     case "reload" -> commandReloadConsole(sender);
                     case "help", "?" -> commandHelpConsole(sender);
                     case "version" -> commandVersionConsole(sender);
                     default -> {
-                        sender.sendMessage(plugin.getLang().getMessage("noconsolecom", "warn"));
+                        sender.sendMessage(plugin.getLang().getMessage("noconsolecom","warn"));
                     }
                 }
                 return true;
@@ -88,7 +88,7 @@ public class CommandEx implements CommandExecutor, TabCompleter {
 
         }
 
-        if (sender instanceof Player player && !getPermissionBasic(player)) {
+        if(sender instanceof Player player && !getPermissionBasic( player)){
             sender.sendMessage(plugin.getLang().getMessage("noperm", "warn"));
             return true;
         } else {
@@ -149,20 +149,20 @@ public class CommandEx implements CommandExecutor, TabCompleter {
             stack.setItemMeta(meta);
             player.getInventory().addItem(stack);
             player.sendMessage(plugin.getLang().getMessage("give", "info"));
-        } else {
+        } else{
             player.sendMessage(plugin.getLang().getMessage("nogive", "warn"));
         }
     }
 
-    private void commandGivePlayerHead(Player player, String[] args) {
-        if (plugin.getAllowedToRetrievePlayerHead() && checkPermission(player, "head", true)) {
+    private void commandGivePlayerHead(Player player,String[] args) {
+          if(plugin.getAllowedToRetrievePlayerHead() && checkPermission(player, "head", true)){
 
-            if (args.length == 2) {
+            if(args.length == 2){
 
                 //Get the Player head Texture
                 String skinTexture = getPlayerHeadTexture(args[1]);
 
-                if (skinTexture == null) {
+                if(skinTexture == null){
                     player.sendMessage(plugin.getLang().getMessage("playerheaderror", "warn"));
                 }
 
@@ -198,16 +198,16 @@ public class CommandEx implements CommandExecutor, TabCompleter {
 
                 //Add the head to the Players Inventory + display PlayerHead Success Message
                 player.getInventory().addItem(playerHead);
-                player.sendMessage(plugin.getLang().getMessage("playerhead", "info"));
+                player.sendMessage(plugin.getLang().getMessage("playerhead","info"));
 
                 //Let Admins know this command has been ran
-                for (Player onlineList : Bukkit.getOnlinePlayers()) {
-                    if (onlineList.hasPermission("asedit.permpack.admin") && plugin.getAdminOnlyNotifications()) {
+                for(Player onlineList : Bukkit.getOnlinePlayers()){
+                    if(onlineList.hasPermission("asedit.permpack.admin") && plugin.getAdminOnlyNotifications()){
                         onlineList.sendMessage(ChatColor.YELLOW + "[ArmorStandEditor] " + player.getName() + "has just used the /ase playerhead command to get the head for " + args[1]);
                     }
                 }
             }
-        } else {
+        } else{
             player.sendMessage(plugin.getLang().getMessage("noplayerhead", "warn"));
         }
     }
@@ -251,7 +251,7 @@ public class CommandEx implements CommandExecutor, TabCompleter {
                     player.sendMessage(LISTSLOT);
                 }
 
-            } catch (NumberFormatException nfe) {
+            } catch ( NumberFormatException nfe) {
                 player.sendMessage(LISTSLOT);
             }
         }
@@ -264,7 +264,7 @@ public class CommandEx implements CommandExecutor, TabCompleter {
         }
 
         if (args.length > 1) {
-            for (AdjustmentMode adj : AdjustmentMode.values()) {
+            for ( AdjustmentMode adj : AdjustmentMode.values()) {
                 if (adj.toString().toLowerCase().contentEquals(args[1].toLowerCase())) {
                     plugin.editorManager.getPlayerEditor(player.getUniqueId()).setAdjMode(adj);
                     return;
@@ -274,14 +274,14 @@ public class CommandEx implements CommandExecutor, TabCompleter {
         }
     }
 
-    private void commandAxis(Player player, String[] args) {
+    private void commandAxis( Player player,  String[] args) {
         if (args.length <= 1) {
             player.sendMessage(plugin.getLang().getMessage("noaxiscom", "warn"));
             player.sendMessage(LISTAXIS);
         }
 
         if (args.length > 1) {
-            for (Axis axis : Axis.values()) {
+            for ( Axis axis : Axis.values()) {
                 if (axis.toString().toLowerCase().contentEquals(args[1].toLowerCase())) {
                     plugin.editorManager.getPlayerEditor(player.getUniqueId()).setAxis(axis);
                     return;
@@ -291,14 +291,14 @@ public class CommandEx implements CommandExecutor, TabCompleter {
         }
     }
 
-    private void commandMode(Player player, String[] args) {
+    private void commandMode( Player player,  String[] args) {
         if (args.length <= 1) {
             player.sendMessage(plugin.getLang().getMessage("nomodecom", "warn"));
             player.sendMessage(LISTMODE);
         }
 
         if (args.length > 1) {
-            for (EditMode mode : EditMode.values()) {
+            for ( EditMode mode : EditMode.values()) {
                 if (mode.toString().toLowerCase().contentEquals(args[1].toLowerCase())) {
                     if (args[1].equals("invisible") && !checkPermission(player, "togglearmorstandvisibility", true)) return;
                     if (args[1].equals("itemframe") && !checkPermission(player, "toggleitemframevisibility", true)) return;
@@ -354,13 +354,13 @@ public class CommandEx implements CommandExecutor, TabCompleter {
         player.sendMessage(ChatColor.YELLOW + "[ArmorStandEditor] Version: " + verString);
     }
 
-    private void commandVersionConsole(CommandSender sender) {
+    private void commandVersionConsole(CommandSender sender){
         String verString = plugin.getArmorStandEditorVersion();
         sender.sendMessage(ChatColor.YELLOW + "[ArmorStandEditor] Version: " + verString);
     }
 
-    private void commandReload(Player player) {
-        if (!(getPermissionReload(player))) return;
+    private void commandReload(Player player){
+        if(!(getPermissionReload(player))) return;
         plugin.performReload();
         player.sendMessage(plugin.getLang().getMessage("reloaded", ""));
     }
@@ -370,7 +370,7 @@ public class CommandEx implements CommandExecutor, TabCompleter {
         sender.sendMessage(plugin.getLang().getMessage("reloaded", "info"));
     }
 
-    private boolean checkPermission(Player player, String permName, boolean sendMessageOnInvalidation) {
+    private boolean checkPermission(Player player, String permName,  boolean sendMessageOnInvalidation) {
         if (permName.equalsIgnoreCase("paste")) {
             permName = "copy";
         }
@@ -388,11 +388,9 @@ public class CommandEx implements CommandExecutor, TabCompleter {
         return checkPermission(player, "basic", false);
     }
 
-    private boolean getPermissionGive(Player player) {
-        return checkPermission(player, "give", false);
-    }
+    private boolean getPermissionGive(Player player) { return checkPermission(player, "give", false); }
 
-    private boolean getPermissionUpdate(Player player) {
+    private boolean getPermissionUpdate(Player player){
         return checkPermission(player, "update", false);
     }
 
@@ -400,9 +398,7 @@ public class CommandEx implements CommandExecutor, TabCompleter {
         return checkPermission(player, "reload", false);
     }
 
-    private boolean getPermissionPlayerHead(Player player) {
-        return checkPermission(player, "head", false);
-    }
+    private boolean getPermissionPlayerHead(Player player) { return checkPermission(player, "head", false); }
 
     //REFACTOR COMPLETION
     @Override
@@ -421,16 +417,16 @@ public class CommandEx implements CommandExecutor, TabCompleter {
                 argList.add("?");
 
                 //Will Only work with permissions
-                if (getPermissionGive(player)) {
+                if(getPermissionGive(player)){
                     argList.add("give");
                 }
-                if (getPermissionUpdate(player)) {
+                if(getPermissionUpdate(player)){
                     argList.add("update");
                 }
-                if (getPermissionReload(player)) {
+                if(getPermissionReload(player)){
                     argList.add("reload");
                 }
-                if (getPermissionPlayerHead(player) && plugin.getAllowedToRetrievePlayerHead()) {
+                if(getPermissionPlayerHead(player) && plugin.getAllowedToRetrievePlayerHead()){
                     argList.add("playerhead");
                 }
             }
@@ -459,17 +455,17 @@ public class CommandEx implements CommandExecutor, TabCompleter {
 
     private boolean isCommandValid(String commandName) {
         return commandName.equalsIgnoreCase("ase") ||
-            commandName.equalsIgnoreCase("armorstandeditor") ||
-            commandName.equalsIgnoreCase("asedit");
+                commandName.equalsIgnoreCase("armorstandeditor") ||
+                commandName.equalsIgnoreCase("asedit");
     }
 
     private List<String> getModeOptions() {
         return List.of(
-            "None", "Invisible", "ShowArms", "Gravity", "BasePlate",
-            "Size", "Copy", "Paste", "Head", "Body", "LeftArm",
-            "RightArm", "LeftLeg", "RightLeg", "Placement",
-            "DisableSlots", "Rotate", "Equipment", "Reset",
-            "ItemFrame", "ItemFrameGlow"
+                "None", "Invisible", "ShowArms", "Gravity", "BasePlate",
+                "Size", "Copy", "Paste", "Head", "Body", "LeftArm",
+                "RightArm", "LeftLeg", "RightLeg", "Placement",
+                "DisableSlots", "Rotate", "Equipment", "Reset",
+                "ItemFrame", "ItemFrameGlow"
         );
     }
 

--- a/src/main/java/io/github/rypofalem/armorstandeditor/CommandEx.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/CommandEx.java
@@ -89,7 +89,7 @@ public class CommandEx implements CommandExecutor, TabCompleter {
         }
 
         if (sender instanceof Player player && !getPermissionBasic(player)) {
-            sender.sendMessage(plugin.getLang().getMessage("noperm", "warn"));
+            sender.sendMessage(plugin.getLang().getMessage("nopermoption", "warn", "basic"));
             return true;
         } else {
 

--- a/src/main/java/io/github/rypofalem/armorstandeditor/CommandEx.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/CommandEx.java
@@ -382,34 +382,89 @@ public class CommandEx implements CommandExecutor, TabCompleter {
             if(e instanceof ArmorStand as){
 
                 //Calculation TIME - Might move this out later, but is OK here for now
-                double headX = as.getHeadPose().getX(); headX = Math.toDegrees(headX); headX = Math.rint(headX);
-                double headY = as.getHeadPose().getY(); headY = Math.toDegrees(headY); headY = Math.rint(headY);
-                double headZ = as.getHeadPose().getZ(); headZ = Math.toDegrees(headZ); headZ = Math.rint(headZ);
+                double headX = as.getHeadPose().getX();
+                headX = Math.toDegrees(headX);
+                headX = Math.rint(headX);
 
-                double bodyX = as.getBodyPose().getX(); bodyX = Math.toDegrees(bodyX); bodyX = Math.rint(bodyX);
-                double bodyY = as.getBodyPose().getY(); bodyY = Math.toDegrees(bodyY); bodyY = Math.rint(bodyY);
-                double bodyZ = as.getBodyPose().getZ(); bodyZ = Math.toDegrees(bodyZ); bodyZ = Math.rint(bodyZ);
+                double headY = as.getHeadPose().getY();
+                headY = Math.toDegrees(headY);
+                headY = Math.rint(headY);
 
-                double rightArmX = as.getRightArmPose().getX(); rightArmX = Math.toDegrees(rightArmX); rightArmX = Math.rint(rightArmX);
-                double rightArmY = as.getRightArmPose().getY(); rightArmY = Math.toDegrees(rightArmY); rightArmY = Math.rint(rightArmY);
-                double rightArmZ = as.getRightArmPose().getZ(); rightArmZ = Math.toDegrees(rightArmZ); rightArmZ = Math.rint(rightArmZ);
+                double headZ = as.getHeadPose().getZ();
+                headZ = Math.toDegrees(headZ);
+                headZ = Math.rint(headZ);
 
-                double leftArmX = as.getLeftArmPose().getX(); leftArmX = Math.toDegrees(leftArmX); leftArmX = Math.rint(leftArmX);
-                double leftArmY = as.getLeftArmPose().getY(); leftArmY = Math.toDegrees(leftArmY); leftArmY = Math.rint(leftArmY);
-                double leftArmZ = as.getLeftArmPose().getZ(); leftArmZ = Math.toDegrees(leftArmZ); leftArmZ = Math.rint(leftArmZ);
+                //Body
+                double bodyX = as.getBodyPose().getX();
+                bodyX = Math.toDegrees(bodyX);
+                bodyX = Math.rint(bodyX);
 
-                double rightLegX = as.getRightLegPose().getX(); rightLegX = Math.toDegrees(rightLegX); rightLegX = Math.rint(rightLegX);
-                double rightLegY = as.getRightLegPose().getY(); rightLegY = Math.toDegrees(rightLegY); rightLegY = Math.rint(rightLegY);
-                double rightLegZ = as.getRightLegPose().getZ(); rightLegZ = Math.toDegrees(rightLegZ); rightArmX = Math.rint(rightLegZ);
+                double bodyY = as.getBodyPose().getY();
+                bodyY = Math.toDegrees(bodyY);
+                bodyY = Math.rint(bodyY);
 
-                double leftLegX = as.getLeftLegPose().getX(); leftLegX = Math.toDegrees(leftLegX); leftLegX = Math.rint(leftLegX);
-                double leftLegY = as.getLeftLegPose().getY(); leftLegY = Math.toDegrees(leftLegY); leftLegY = Math.rint(leftLegY);
-                double leftLegZ = as.getLeftLegPose().getZ(); leftLegZ = Math.toDegrees(leftLegZ); leftLegZ = Math.rint(leftLegZ);
+                double bodyZ = as.getBodyPose().getZ();
+                bodyZ = Math.toDegrees(bodyZ);
+                bodyZ = Math.rint(bodyZ);
 
+
+                //Arms
+                double rightArmX = as.getRightArmPose().getX();
+                rightArmX = Math.toDegrees(rightArmX);
+                rightArmX = Math.rint(rightArmX);
+
+                double rightArmY = as.getRightArmPose().getY();
+                rightArmY = Math.toDegrees(rightArmY);
+                rightArmY = Math.rint(rightArmY);
+
+                double rightArmZ = as.getRightArmPose().getZ();
+                rightArmZ = Math.toDegrees(rightArmZ);
+                rightArmZ = Math.rint(rightArmZ);
+
+
+                double leftArmX = as.getLeftArmPose().getX();
+                leftArmX = Math.toDegrees(leftArmX);
+                leftArmX = Math.rint(leftArmX);
+
+                double leftArmY = as.getLeftArmPose().getY();
+                leftArmY = Math.toDegrees(leftArmY);
+                leftArmY = Math.rint(leftArmY);
+
+                double leftArmZ = as.getLeftArmPose().getZ();
+                leftArmZ = Math.toDegrees(leftArmZ);
+                leftArmZ = Math.rint(leftArmZ);
+
+                //Legs
+                double rightLegX = as.getRightLegPose().getX();
+                rightLegX = Math.toDegrees(rightLegX);
+                rightLegX = Math.rint(rightLegX);
+
+                double rightLegY = as.getRightLegPose().getY();
+                rightLegY = Math.toDegrees(rightLegY);
+                rightLegY = Math.rint(rightLegY);
+
+                double rightLegZ = as.getRightLegPose().getZ();
+                rightLegZ = Math.toDegrees(rightLegZ);
+                rightArmX = Math.rint(rightLegZ);
+
+                double leftLegX = as.getLeftLegPose().getX();
+                leftLegX = Math.toDegrees(leftLegX);
+                leftLegX = Math.rint(leftLegX);
+
+                double leftLegY = as.getLeftLegPose().getY();
+                leftLegY = Math.toDegrees(leftLegY);
+                leftLegY = Math.rint(leftLegY);
+
+                double leftLegZ = as.getLeftLegPose().getZ();
+                leftLegZ = Math.toDegrees(leftLegZ);
+                leftLegZ = Math.rint(leftLegZ);
+
+                //Coordinates
                 float locationX = (float) as.getLocation().getX();
                 float locationY = (float) as.getLocation().getY();
                 float locationZ = (float) as.getLocation().getZ();
 
+                //Toggles
                 boolean isVisible = as.isVisible();
                 boolean armsVisible = as.hasArms();
                 boolean basePlateVisible = as.hasBasePlate();

--- a/src/main/java/io/github/rypofalem/armorstandeditor/CommandEx.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/CommandEx.java
@@ -88,7 +88,7 @@ public class CommandEx implements CommandExecutor, TabCompleter {
 
         }
 
-        if(sender instanceof Player && !getPermissionBasic( (Player) sender)){
+        if(sender instanceof Player player && !getPermissionBasic( player)){
             sender.sendMessage(plugin.getLang().getMessage("noperm", "warn"));
             return true;
         } else {

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
@@ -212,6 +212,7 @@ public class PlayerEditor {
 
     private void openEquipment(ArmorStand armorStand) {
         if (!getPlayer().hasPermission("asedit.equipment")) return;
+        //if (team != null && team.hasEntry(armorStand.getName())) return; //Do not allow editing if the ArmorStand is Disabled
         equipMenu = new EquipmentMenu(this, armorStand);
         equipMenu.open();
     }

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
@@ -170,6 +170,9 @@ public class PlayerEditor {
                 case RESET:
                     resetPosition(armorStand);
                     break;
+                case GLOWING:
+                    toggleGlowing(armorStand);
+                    break;
                 case NONE:
                 default:
                     sendMessage("nomode", null);
@@ -426,6 +429,17 @@ public class PlayerEditor {
             sendMessage("nopermoption", "warn", "baseplate");
         }
 
+    }
+
+    void toggleGlowing(ArmorStand armorStand){
+        if(getPlayer().hasPermission("asedit.togglearmorstandglow")){
+            //Will only make it glow white - Not something we can do like with Locking. Do not request this!
+            //Otherwise, this simple function becomes a mess to maintain. As you would need a Team generated with each
+            //Color and I ain't going to impose that on servers.
+            armorStand.setGlowing(!armorStand.isGlowing());
+        } else{
+            sendMessage("nopermoption", "warn", "armorstandglow");
+        }
     }
 
     void toggleArms(ArmorStand armorStand) {

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
@@ -408,8 +408,11 @@ public class PlayerEditor {
     }
 
     void toggleVisible(ArmorStand armorStand) {
-        if (!getPlayer().hasPermission("asedit.togglearmorstandvisibility") || !plugin.armorStandVisibility) return; //Option to use perms or Config
-        armorStand.setVisible(!armorStand.isVisible());
+        if(getPlayer().hasPermission("asedit.togglearmorstandvisibility") || plugin.getArmorStandVisibility()){
+            armorStand.setVisible(!armorStand.isVisible());
+        } else{
+            getPlayer().sendMessage();
+        }
     }
 
     void toggleItemFrameVisible(ItemFrame itemFrame) {

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
@@ -109,105 +109,97 @@ public class PlayerEditor {
     }
 
     public void editArmorStand(ArmorStand armorStand) {
-        if (!getPlayer().hasPermission("asedit.basic")) return;
+        if (getPlayer().hasPermission("asedit.basic")) {
 
-        armorStand = attemptTarget(armorStand);
-        switch (eMode) {
-            case LEFTARM:
-                armorStand.setLeftArmPose(subEulerAngle(armorStand.getLeftArmPose()));
-                break;
-            case RIGHTARM:
-                armorStand.setRightArmPose(subEulerAngle(armorStand.getRightArmPose()));
-                break;
-            case BODY:
-                armorStand.setBodyPose(subEulerAngle(armorStand.getBodyPose()));
-                break;
-            case HEAD:
-                armorStand.setHeadPose(subEulerAngle(armorStand.getHeadPose()));
-                break;
-            case LEFTLEG:
-                armorStand.setLeftLegPose(subEulerAngle(armorStand.getLeftLegPose()));
-                break;
-            case RIGHTLEG:
-                armorStand.setRightLegPose(subEulerAngle(armorStand.getRightLegPose()));
-                break;
-            case SHOWARMS:
-                toggleArms(armorStand);
-                break;
-            case SIZE:
-                toggleSize(armorStand);
-                break;
-            case INVISIBLE:
-                toggleVisible(armorStand);
-                break;
-            case BASEPLATE:
-                togglePlate(armorStand);
-                break;
-            case GRAVITY:
-                toggleGravity(armorStand);
-                break;
-            case COPY:
-                copy(armorStand);
-                break;
-            case PASTE:
-                paste(armorStand);
-                break;
-            case PLACEMENT:
-                move(armorStand);
-                break;
-            case ROTATE:
-                rotate(armorStand);
-                break;
-            case DISABLESLOTS:
-                toggleDisableSlots(armorStand);
-                break;
-            case VULNERABILITY:
-                toggleInvulnerability(armorStand);
-                break;
-            case EQUIPMENT:
-                openEquipment(armorStand);
-                break;
-            case RESET:
-                resetPosition(armorStand);
-                break;
-            case NONE:
-            default:
-                sendMessage("nomode", null);
-                break;
+            armorStand = attemptTarget(armorStand);
+            switch (eMode) {
+                case LEFTARM:
+                    armorStand.setLeftArmPose(subEulerAngle(armorStand.getLeftArmPose()));
+                    break;
+                case RIGHTARM:
+                    armorStand.setRightArmPose(subEulerAngle(armorStand.getRightArmPose()));
+                    break;
+                case BODY:
+                    armorStand.setBodyPose(subEulerAngle(armorStand.getBodyPose()));
+                    break;
+                case HEAD:
+                    armorStand.setHeadPose(subEulerAngle(armorStand.getHeadPose()));
+                    break;
+                case LEFTLEG:
+                    armorStand.setLeftLegPose(subEulerAngle(armorStand.getLeftLegPose()));
+                    break;
+                case RIGHTLEG:
+                    armorStand.setRightLegPose(subEulerAngle(armorStand.getRightLegPose()));
+                    break;
+                case SHOWARMS:
+                    toggleArms(armorStand);
+                    break;
+                case SIZE:
+                    toggleSize(armorStand);
+                    break;
+                case INVISIBLE:
+                    toggleVisible(armorStand);
+                    break;
+                case BASEPLATE:
+                    togglePlate(armorStand);
+                    break;
+                case GRAVITY:
+                    toggleGravity(armorStand);
+                    break;
+                case COPY:
+                    copy(armorStand);
+                    break;
+                case PASTE:
+                    paste(armorStand);
+                    break;
+                case PLACEMENT:
+                    move(armorStand);
+                    break;
+                case ROTATE:
+                    rotate(armorStand);
+                    break;
+                case DISABLESLOTS:
+                    toggleDisableSlots(armorStand);
+                    break;
+                case VULNERABILITY:
+                    toggleInvulnerability(armorStand);
+                    break;
+                case EQUIPMENT:
+                    openEquipment(armorStand);
+                    break;
+                case RESET:
+                    resetPosition(armorStand);
+                    break;
+                case NONE:
+                default:
+                    sendMessage("nomode", null);
+                    break;
 
-        }
+            }
+        }else return;
     }
 
     public void editItemFrame(ItemFrame itemFrame) {
-        if (!getPlayer().hasPermission("asedit.toggleitemframevisibility") || !plugin.invisibleItemFrames) return; //Option to use perms or Config
+        if (getPlayer().hasPermission("asedit.toggleitemframevisibility") || plugin.invisibleItemFrames) {
 
-        //Generate a new ArmorStandManipulationEvent and call it out.
-        ItemFrameManipulatedEvent event = new ItemFrameManipulatedEvent(itemFrame, getPlayer());
-        Bukkit.getPluginManager().callEvent(event); // Bukkit handles the call out
-        if (event.isCancelled()) return; //do nothing if cancelled
+            //Generate a new ArmorStandManipulationEvent and call it out.
+            ItemFrameManipulatedEvent event = new ItemFrameManipulatedEvent(itemFrame, getPlayer());
+            Bukkit.getPluginManager().callEvent(event); // Bukkit handles the call out
+            if (event.isCancelled()) return; //do nothing if cancelled
 
-        switch (eMode) {
-            case ITEMFRAME:
-                toggleItemFrameVisible(itemFrame);
-                break;
-            case RESET:
-                itemFrame.setVisible(true);
-                break;
-            case NONE:
-            default:
-                sendMessage("nomodeif", null);
-                break;
-        }
-    }
-
-    private void resetPosition(ArmorStand armorStand) {
-        if (!getPlayer().hasPermission("asedit.reset")) return;
-        armorStand.setHeadPose(new EulerAngle(0, 0, 0));
-        armorStand.setBodyPose(new EulerAngle(0, 0, 0));
-        armorStand.setLeftArmPose(new EulerAngle(0, 0, 0));
-        armorStand.setRightArmPose(new EulerAngle(0, 0, 0));
-        armorStand.setLeftLegPose(new EulerAngle(0, 0, 0));
-        armorStand.setRightLegPose(new EulerAngle(0, 0, 0));
+            switch (eMode) {
+                case ITEMFRAME:
+                    toggleItemFrameVisible(itemFrame);
+                    break;
+                case RESET:
+                    itemFrame.setVisible(true);
+                    break;
+                case NONE:
+                default:
+                    sendMessage("nomodeif", null);
+                    break;
+            }
+        }else return;
     }
 
     private void openEquipment(ArmorStand armorStand) {
@@ -313,116 +305,159 @@ public class PlayerEditor {
     }
 
     private void copy(ArmorStand armorStand) {
-        if (!getPlayer().hasPermission("asedit.copy")) return;
-        copySlots.copyDataToSlot(armorStand);
-        sendMessage("copied", "" + (copySlots.currentSlot + 1));
-        setMode(EditMode.PASTE);
+        if (getPlayer().hasPermission("asedit.copy")) {
+            copySlots.copyDataToSlot(armorStand);
+            sendMessage("copied", "" + (copySlots.currentSlot + 1));
+            setMode(EditMode.PASTE);
+        }else{
+            sendMessage("nopermoption", "warn", "copy");
+        }
+
     }
 
     private void paste(ArmorStand armorStand) {
-        if (!getPlayer().hasPermission("asedit.paste")) return;
-        ArmorStandData data = copySlots.getDataToPaste();
-        if (data == null) return;
-        armorStand.setHeadPose(data.headPos);
-        armorStand.setBodyPose(data.bodyPos);
-        armorStand.setLeftArmPose(data.leftArmPos);
-        armorStand.setRightArmPose(data.rightArmPos);
-        armorStand.setLeftLegPose(data.leftLegPos);
-        armorStand.setRightLegPose(data.rightLegPos);
-        armorStand.setSmall(data.size);
-        armorStand.setGravity(data.gravity);
-        armorStand.setBasePlate(data.basePlate);
-        armorStand.setArms(data.showArms);
-        armorStand.setVisible(data.visible);
+        if (getPlayer().hasPermission("asedit.paste")) {
+            ArmorStandData data = copySlots.getDataToPaste();
+            if (data == null) return;
+            armorStand.setHeadPose(data.headPos);
+            armorStand.setBodyPose(data.bodyPos);
+            armorStand.setLeftArmPose(data.leftArmPos);
+            armorStand.setRightArmPose(data.rightArmPos);
+            armorStand.setLeftLegPose(data.leftLegPos);
+            armorStand.setRightLegPose(data.rightLegPos);
+            armorStand.setSmall(data.size);
+            armorStand.setGravity(data.gravity);
+            armorStand.setBasePlate(data.basePlate);
+            armorStand.setArms(data.showArms);
+            armorStand.setVisible(data.visible);
 
-        //Only Paste the Items on the stand if in Creative Mode
-        // - Do not run elsewhere for good fecking reason!
-        if (this.getPlayer().getGameMode() == GameMode.CREATIVE) {
-            armorStand.getEquipment().setHelmet(data.head);
-            armorStand.getEquipment().setChestplate(data.body);
-            armorStand.getEquipment().setLeggings(data.legs);
-            armorStand.getEquipment().setBoots(data.feetsies);
-            armorStand.getEquipment().setItemInMainHand(data.rightHand);
-            armorStand.getEquipment().setItemInOffHand(data.leftHand);
+            //Only Paste the Items on the stand if in Creative Mode
+            // - Do not run elsewhere for good fecking reason!
+            if (this.getPlayer().getGameMode() == GameMode.CREATIVE) {
+                armorStand.getEquipment().setHelmet(data.head);
+                armorStand.getEquipment().setChestplate(data.body);
+                armorStand.getEquipment().setLeggings(data.legs);
+                armorStand.getEquipment().setBoots(data.feetsies);
+                armorStand.getEquipment().setItemInMainHand(data.rightHand);
+                armorStand.getEquipment().setItemInOffHand(data.leftHand);
+            }
+            sendMessage("pasted", "" + (copySlots.currentSlot + 1));
+        }else{
+            sendMessage("nopermoption", "warn", "paste");
         }
-        sendMessage("pasted", "" + (copySlots.currentSlot + 1));
+    }
+
+    private void resetPosition(ArmorStand armorStand) {
+        if (getPlayer().hasPermission("asedit.reset")) {
+            armorStand.setHeadPose(new EulerAngle(0, 0, 0));
+            armorStand.setBodyPose(new EulerAngle(0, 0, 0));
+            armorStand.setLeftArmPose(new EulerAngle(0, 0, 0));
+            armorStand.setRightArmPose(new EulerAngle(0, 0, 0));
+            armorStand.setLeftLegPose(new EulerAngle(0, 0, 0));
+            armorStand.setRightLegPose(new EulerAngle(0, 0, 0));
+        } else{
+            sendMessage("nopermoption", "warn", "reset");
+        }
     }
 
     private void toggleDisableSlots(ArmorStand armorStand) {
-        if (!getPlayer().hasPermission("asedit.disableSlots")) return;
-        if (armorStand.hasEquipmentLock(EquipmentSlot.HAND, ArmorStand.LockType.REMOVING_OR_CHANGING)) { //Adds a lock to every slot or removes it
-            team = Scheduler.isFolia() ? null : plugin.scoreboard.getTeam(plugin.lockedTeam);
-            armorStandID = armorStand.getUniqueId();
-
-            for (final EquipmentSlot slot : EquipmentSlot.values()) { // UNLOCKED
-                armorStand.removeEquipmentLock(slot, ArmorStand.LockType.REMOVING_OR_CHANGING);
-                armorStand.removeEquipmentLock(slot, ArmorStand.LockType.ADDING);
-            }
-            getPlayer().playSound(getPlayer().getLocation(), Sound.ENTITY_ITEM_BREAK, SoundCategory.PLAYERS, 1.0f, 1.0f);
-
-            if (team != null) {
-                team.removeEntry(armorStandID.toString());
-                armorStand.addPotionEffect(new PotionEffect(PotionEffectType.GLOWING, 50, 1, false, false)); //300 Ticks = 15 seconds
-            }
-
-
+        if (!getPlayer().hasPermission("asedit.disableSlots")){
+            sendMessage("nopermoption", "warn", "disableslots");
         } else {
-            for (final EquipmentSlot slot : EquipmentSlot.values()) { //LOCKED
-                armorStand.addEquipmentLock(slot, ArmorStand.LockType.REMOVING_OR_CHANGING);
-                armorStand.addEquipmentLock(slot, ArmorStand.LockType.ADDING);
-            }
-            getPlayer().playSound(getPlayer().getLocation(), Sound.ITEM_ARMOR_EQUIP_IRON, SoundCategory.PLAYERS, 1.0f, 1.0f);
-            if (team != null) {
-                team.addEntry(armorStandID.toString());
-                armorStand.addPotionEffect(new PotionEffect(PotionEffectType.GLOWING, 50, 1, false, false)); //300 Ticks = 15 seconds
-            }
-        }
+            if (armorStand.hasEquipmentLock(EquipmentSlot.HAND, ArmorStand.LockType.REMOVING_OR_CHANGING)) { //Adds a lock to every slot or removes it
+                team = Scheduler.isFolia() ? null : plugin.scoreboard.getTeam(plugin.lockedTeam);
+                armorStandID = armorStand.getUniqueId();
 
-        sendMessage("disabledslots", null);
+                for (final EquipmentSlot slot : EquipmentSlot.values()) { // UNLOCKED
+                    armorStand.removeEquipmentLock(slot, ArmorStand.LockType.REMOVING_OR_CHANGING);
+                    armorStand.removeEquipmentLock(slot, ArmorStand.LockType.ADDING);
+                }
+                getPlayer().playSound(getPlayer().getLocation(), Sound.ENTITY_ITEM_BREAK, SoundCategory.PLAYERS, 1.0f, 1.0f);
+
+                if (team != null) {
+                    team.removeEntry(armorStandID.toString());
+                    armorStand.addPotionEffect(new PotionEffect(PotionEffectType.GLOWING, 50, 1, false, false)); //300 Ticks = 15 seconds
+                }
+
+
+            } else {
+                for (final EquipmentSlot slot : EquipmentSlot.values()) { //LOCKED
+                    armorStand.addEquipmentLock(slot, ArmorStand.LockType.REMOVING_OR_CHANGING);
+                    armorStand.addEquipmentLock(slot, ArmorStand.LockType.ADDING);
+                }
+                getPlayer().playSound(getPlayer().getLocation(), Sound.ITEM_ARMOR_EQUIP_IRON, SoundCategory.PLAYERS, 1.0f, 1.0f);
+                if (team != null) {
+                    team.addEntry(armorStandID.toString());
+                    armorStand.addPotionEffect(new PotionEffect(PotionEffectType.GLOWING, 50, 1, false, false)); //300 Ticks = 15 seconds
+                }
+            }
+
+            sendMessage("disabledslots", null);
+        }
 
     }
 
     private void toggleInvulnerability(ArmorStand armorStand) { //See NewFeature-Request #256 for more info
-        if (!getPlayer().hasPermission("asedit.toggleInvulnerability")) return;
-        armorStand.setInvulnerable(!armorStand.isInvulnerable());
-        sendMessage("toggleinvulnerability", String.valueOf(armorStand.isInvulnerable()));
+        if (getPlayer().hasPermission("asedit.toggleInvulnerability")) {
+            armorStand.setInvulnerable(!armorStand.isInvulnerable());
+            sendMessage("toggleinvulnerability", String.valueOf(armorStand.isInvulnerable()));
+        } else {
+            sendMessage("nopermoption","warn", "vulnerability");
+        }
     }
 
 
     private void toggleGravity(ArmorStand armorStand) {
-        if (!getPlayer().hasPermission("asedit.togglegravity")) return;
+        if (getPlayer().hasPermission("asedit.togglegravity")){
+            armorStand.setGravity(!armorStand.hasGravity());
+            sendMessage("setgravity", String.valueOf(armorStand.hasGravity()));//Fix for Wolfst0rm/ArmorStandEditor-Issues#6: Translation of On/Off Keys are broken
+        } else{
+            sendMessage("nopermoption","warn", "gravity");
+        }
 
-        //Fix for Wolfst0rm/ArmorStandEditor-Issues#6: Translation of On/Off Keys are broken
-        armorStand.setGravity(!armorStand.hasGravity());
-        sendMessage("setgravity", String.valueOf(armorStand.hasGravity()));
+
+
     }
 
     void togglePlate(ArmorStand armorStand) {
-        if (!getPlayer().hasPermission("asedit.togglebaseplate")) return;
-        armorStand.setBasePlate(!armorStand.hasBasePlate());
+        if(getPlayer().hasPermission("asedit.togglebaseplate")){
+            armorStand.setBasePlate(!armorStand.hasBasePlate());
+        } else{
+            sendMessage("nopermoption", "warn", "baseplate");
+        }
+
     }
 
     void toggleArms(ArmorStand armorStand) {
-        if (!getPlayer().hasPermission("asedit.togglearms")) return;
-        armorStand.setArms(!armorStand.hasArms());
+        if(getPlayer().hasPermission("asedit.togglearms")){
+            armorStand.setArms(!armorStand.hasArms());
+        }else{
+            sendMessage("nopermoption", "warn", "showarms");
+        }
     }
 
     void toggleVisible(ArmorStand armorStand) {
         if(getPlayer().hasPermission("asedit.togglearmorstandvisibility") || plugin.getArmorStandVisibility()){
             armorStand.setVisible(!armorStand.isVisible());
-        } else{
-            getPlayer().sendMessage();
+        } else{ //Throw No Permission Message
+            sendMessage("nopermoption", "warn", "armorstandvisibility");
         }
     }
 
     void toggleItemFrameVisible(ItemFrame itemFrame) {
-        if (!getPlayer().hasPermission("asedit.toggleitemframevisibility") || !plugin.invisibleItemFrames) return; //Option to use perms or Config
-        itemFrame.setVisible(!itemFrame.isVisible());
+        if (getPlayer().hasPermission("asedit.toggleitemframevisibility") || plugin.invisibleItemFrames) { //Option to use perms or Config
+            itemFrame.setVisible(!itemFrame.isVisible());
+        }else {
+            sendMessage("nopermoption", "warn", "itemframevisibility");
+        }
     }
 
     void toggleSize(ArmorStand armorStand) {
-        if (!getPlayer().hasPermission("asedit.togglesize")) return;
-        armorStand.setSmall(!armorStand.isSmall());
+        if (getPlayer().hasPermission("asedit.togglesize")) {
+            armorStand.setSmall(!armorStand.isSmall());
+        } else {
+            sendMessage("nopermoption", "warn", "size");
+        }
     }
 
     void cycleAxis(int i) {

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
@@ -18,6 +18,9 @@
  */
 package io.github.rypofalem.armorstandeditor;
 
+import net.md_5.bungee.api.ChatMessageType;
+import net.md_5.bungee.api.chat.TextComponent;
+
 import io.github.rypofalem.armorstandeditor.api.*;
 import io.github.rypofalem.armorstandeditor.menu.EquipmentMenu;
 import io.github.rypofalem.armorstandeditor.menu.Menu;
@@ -27,12 +30,6 @@ import io.github.rypofalem.armorstandeditor.modes.Axis;
 import io.github.rypofalem.armorstandeditor.modes.CopySlots;
 import io.github.rypofalem.armorstandeditor.modes.EditMode;
 
-
-import java.util.ArrayList;
-import java.util.UUID;
-
-import net.md_5.bungee.api.ChatMessageType;
-import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.*;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.ItemFrame;
@@ -42,6 +39,9 @@ import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scoreboard.Team;
 import org.bukkit.util.EulerAngle;
+
+import java.util.ArrayList;
+import java.util.UUID;
 
 public class PlayerEditor {
     public ArmorStandEditorPlugin plugin;
@@ -201,7 +201,7 @@ public class PlayerEditor {
     }
 
     private void resetPosition(ArmorStand armorStand) {
-        if(!getPlayer().hasPermission("asedit.reset")) return;
+        if (!getPlayer().hasPermission("asedit.reset")) return;
         armorStand.setHeadPose(new EulerAngle(0, 0, 0));
         armorStand.setBodyPose(new EulerAngle(0, 0, 0));
         armorStand.setLeftArmPose(new EulerAngle(0, 0, 0));
@@ -256,7 +256,7 @@ public class PlayerEditor {
     }
 
     private void move(ArmorStand armorStand) {
-        if(!getPlayer().hasPermission("asedit.movement")) return;
+        if (!getPlayer().hasPermission("asedit.movement")) return;
 
         //Generate a new ArmorStandManipulationEvent and call it out.
         ArmorStandManipulatedEvent event = new ArmorStandManipulatedEvent(armorStand, getPlayer());
@@ -279,7 +279,7 @@ public class PlayerEditor {
     }
 
     private void reverseMove(ArmorStand armorStand) {
-        if(!getPlayer().hasPermission("asedit.movement")) return;
+        if (!getPlayer().hasPermission("asedit.movement")) return;
         Location loc = armorStand.getLocation();
         switch (axis) {
             case X:
@@ -296,7 +296,7 @@ public class PlayerEditor {
     }
 
     private void rotate(ArmorStand armorStand) {
-        if(!getPlayer().hasPermission("asedit.rotation")) return;
+        if (!getPlayer().hasPermission("asedit.rotation")) return;
         Location loc = armorStand.getLocation();
         float yaw = loc.getYaw();
         loc.setYaw((yaw + 180 + (float) degreeAngleChange) % 360 - 180);
@@ -304,7 +304,7 @@ public class PlayerEditor {
     }
 
     private void reverseRotate(ArmorStand armorStand) {
-        if(!getPlayer().hasPermission("asedit.rotation")) return;
+        if (!getPlayer().hasPermission("asedit.rotation")) return;
         Location loc = armorStand.getLocation();
         float yaw = loc.getYaw();
         loc.setYaw((yaw + 180 - (float) degreeAngleChange) % 360 - 180);
@@ -312,14 +312,14 @@ public class PlayerEditor {
     }
 
     private void copy(ArmorStand armorStand) {
-        if(!getPlayer().hasPermission("asedit.copy")) return;
+        if (!getPlayer().hasPermission("asedit.copy")) return;
         copySlots.copyDataToSlot(armorStand);
         sendMessage("copied", "" + (copySlots.currentSlot + 1));
         setMode(EditMode.PASTE);
     }
 
     private void paste(ArmorStand armorStand) {
-        if(!getPlayer().hasPermission("asedit.paste")) return;
+        if (!getPlayer().hasPermission("asedit.paste")) return;
         ArmorStandData data = copySlots.getDataToPaste();
         if (data == null) return;
         armorStand.setHeadPose(data.headPos);
@@ -359,7 +359,7 @@ public class PlayerEditor {
             }
             getPlayer().playSound(getPlayer().getLocation(), Sound.ENTITY_ITEM_BREAK, SoundCategory.PLAYERS, 1.0f, 1.0f);
 
-            if(team != null) {
+            if (team != null) {
                 team.removeEntry(armorStandID.toString());
                 armorStand.addPotionEffect(new PotionEffect(PotionEffectType.GLOWING, 50, 1, false, false)); //300 Ticks = 15 seconds
             }
@@ -371,7 +371,7 @@ public class PlayerEditor {
                 armorStand.addEquipmentLock(slot, ArmorStand.LockType.ADDING);
             }
             getPlayer().playSound(getPlayer().getLocation(), Sound.ITEM_ARMOR_EQUIP_IRON, SoundCategory.PLAYERS, 1.0f, 1.0f);
-            if(team != null) {
+            if (team != null) {
                 team.addEntry(armorStandID.toString());
                 armorStand.addPotionEffect(new PotionEffect(PotionEffectType.GLOWING, 50, 1, false, false)); //300 Ticks = 15 seconds
             }
@@ -382,15 +382,14 @@ public class PlayerEditor {
     }
 
     private void toggleInvulnerability(ArmorStand armorStand) { //See NewFeature-Request #256 for more info
-        if(!getPlayer().hasPermission("asedit.toggleInvulnerability")) return;
+        if (!getPlayer().hasPermission("asedit.toggleInvulnerability")) return;
         armorStand.setInvulnerable(!armorStand.isInvulnerable());
         sendMessage("toggleinvulnerability", String.valueOf(armorStand.isInvulnerable()));
     }
 
 
-
     private void toggleGravity(ArmorStand armorStand) {
-        if(!getPlayer().hasPermission("asedit.togglegravity")) return;
+        if (!getPlayer().hasPermission("asedit.togglegravity")) return;
 
         //Fix for Wolfst0rm/ArmorStandEditor-Issues#6: Translation of On/Off Keys are broken
         armorStand.setGravity(!armorStand.hasGravity());
@@ -398,12 +397,12 @@ public class PlayerEditor {
     }
 
     void togglePlate(ArmorStand armorStand) {
-        if(!getPlayer().hasPermission("asedit.togglebaseplate")) return;
+        if (!getPlayer().hasPermission("asedit.togglebaseplate")) return;
         armorStand.setBasePlate(!armorStand.hasBasePlate());
     }
 
     void toggleArms(ArmorStand armorStand) {
-        if(!getPlayer().hasPermission("asedit.togglearms")) return;
+        if (!getPlayer().hasPermission("asedit.togglearms")) return;
         armorStand.setArms(!armorStand.hasArms());
     }
 
@@ -418,7 +417,7 @@ public class PlayerEditor {
     }
 
     void toggleSize(ArmorStand armorStand) {
-        if(!getPlayer().hasPermission("asedit.togglesize")) return;
+        if (!getPlayer().hasPermission("asedit.togglesize")) return;
         armorStand.setSmall(!armorStand.isSmall());
     }
 
@@ -542,12 +541,11 @@ public class PlayerEditor {
     }
 
 
-
     ArmorStand attemptTarget(ArmorStand armorStand) {
         if (target == null
-                || !target.isValid()
-                || target.getWorld() != getPlayer().getWorld()
-                || target.getLocation().distanceSquared(getPlayer().getLocation()) > 100)
+            || !target.isValid()
+            || target.getWorld() != getPlayer().getWorld()
+            || target.getLocation().distanceSquared(getPlayer().getLocation()) > 100)
             return armorStand;
         armorStand = target;
         return armorStand;

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
@@ -334,7 +334,8 @@ public class PlayerEditor {
         armorStand.setArms(data.showArms);
         armorStand.setVisible(data.visible);
 
-        //Only Paste the Items on the stand if in Creative Mode - Do not run elsewhere for good fecking reason!
+        //Only Paste the Items on the stand if in Creative Mode
+        // - Do not run elsewhere for good fecking reason!
         if (this.getPlayer().getGameMode() == GameMode.CREATIVE) {
             armorStand.getEquipment().setHelmet(data.head);
             armorStand.getEquipment().setChestplate(data.body);
@@ -607,7 +608,6 @@ public class PlayerEditor {
         @Override
         public void run() {
             if (isMenuCancelled()) return;
-
 
             //API: PlayerOpenMenuEvent
             PlayerOpenMenuEvent event = new PlayerOpenMenuEvent(getPlayer());

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
@@ -560,7 +560,7 @@ public class PlayerEditor {
                 plugin.getServer().getPlayer(getUUID()).spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(message));
             } else {
                 String rawText = plugin.getLang().getRawMessage(path, format, option);
-                String command = String.format("title %s actionbar %s", plugin.getServer().getPlayer(getUUID()).getName(), rawText);
+                String command = "title %s actionbar %s".formatted(plugin.getServer().getPlayer(getUUID()).getName(), rawText);
                 Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command);
             }
         } else {

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
@@ -237,9 +237,8 @@ public class PlayerEditorManager implements Listener {
 
         if(event.getEntity() instanceof ArmorStand entityAS && entityAS.isDead()){
             //TODO: Find a more permanent fix for "Once you destroy that armor stand, the armor stand will keep it's name and colour given by the name tag." THIS IS A TEMP SOLUTION FOR NOW.
-            entityAS.setCustomName(null);
-            entityAS.setCustomNameVisible(false);
-
+            event.getEntity().setCustomName(null);
+            event.getEntity().setCustomNameVisible(false);
             event.setCancelled(false);
         }
     }

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
@@ -20,6 +20,7 @@
 package io.github.rypofalem.armorstandeditor;
 
 import com.google.common.collect.ImmutableList;
+
 import io.github.rypofalem.armorstandeditor.api.ArmorStandRenameEvent;
 import io.github.rypofalem.armorstandeditor.api.ItemFrameGlowEvent;
 import io.github.rypofalem.armorstandeditor.menu.ASEHolder;
@@ -64,16 +65,16 @@ public class PlayerEditorManager implements Listener {
     // Instantiate protections used to determine whether a player may edit an armor stand or item frame
     //NOTE: GriefPreventionProtection is Depreciated as of v1.19.3-40
     private final List<Protection> protections = ImmutableList.of(
-            new GriefDefenderProtection(),
-            new GriefPreventionProtection(),
-            new LandsProtection(),
-            new PlotSquaredProtection(),
-            new SkyblockProtection(),
-            new TownyProtection(),
-            new WorldGuardProtection(),
-            new BentoBoxProtection());
+        new GriefDefenderProtection(),
+        new GriefPreventionProtection(),
+        new LandsProtection(),
+        new PlotSquaredProtection(),
+        new SkyblockProtection(),
+        new TownyProtection(),
+        new WorldGuardProtection(),
+        new BentoBoxProtection());
 
-    PlayerEditorManager( ArmorStandEditorPlugin plugin) {
+    PlayerEditorManager(ArmorStandEditorPlugin plugin) {
         this.plugin = plugin;
         players = new HashMap<>();
         coarseAdj = Util.FULL_CIRCLE / plugin.coarseRot;
@@ -85,7 +86,7 @@ public class PlayerEditorManager implements Listener {
     }
 
     @EventHandler(priority = EventPriority.LOWEST)
-    void onArmorStandDamage( EntityDamageByEntityEvent event) {
+    void onArmorStandDamage(EntityDamageByEntityEvent event) {
         if (!(event.getDamager() instanceof Player)) return;
         Player player = (Player) event.getDamager();
         if (!plugin.isEditTool(player.getInventory().getItemInMainHand())) return;
@@ -109,7 +110,7 @@ public class PlayerEditorManager implements Listener {
     }
 
     @EventHandler(priority = EventPriority.LOWEST)
-    void onArmorStandInteract( PlayerInteractAtEntityEvent event) {
+    void onArmorStandInteract(PlayerInteractAtEntityEvent event) {
         if (ignoreNextInteract) return;
         if (event.getHand() != EquipmentSlot.HAND) return;
         Player player = event.getPlayer();
@@ -180,8 +181,8 @@ public class PlayerEditorManager implements Listener {
             }
 
             if (player.getInventory().getItemInMainHand().getType().equals(Material.GLOW_INK_SAC) //attempt glowing
-                    && player.hasPermission("asedit.basic")
-                    && plugin.glowItemFrames && player.isSneaking()) {
+                && player.hasPermission("asedit.basic")
+                && plugin.glowItemFrames && player.isSneaking()) {
 
                 ItemFrameGlowEvent e = new ItemFrameGlowEvent(itemFrame, player);
                 Bukkit.getPluginManager().callEvent(e);
@@ -217,7 +218,7 @@ public class PlayerEditorManager implements Listener {
 
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     void onArmorStandBreak(EntityDamageByEntityEvent event) { // Fixes issue #309
-        if (!(event.getDamager() instanceof Player))     return; // If the damager is not a player, ignore.
+        if (!(event.getDamager() instanceof Player)) return; // If the damager is not a player, ignore.
         if (!(event.getEntity()  instanceof ArmorStand)) return; // If the damaged entity is not an ArmorStand, ignore.
 
         if (event.getEntity() instanceof ArmorStand entityAS) {
@@ -273,7 +274,7 @@ public class PlayerEditorManager implements Listener {
             List<Entity> nearby = (List<Entity>) player.getWorld().getNearbyEntities(eyeLaser, LASERRADIUS, LASERRADIUS, LASERRADIUS);
             if (!nearby.isEmpty()) {
                 boolean endLaser = false;
-                for ( Entity e : nearby) {
+                for (Entity e : nearby) {
                     if (e instanceof ArmorStand stand) {
                         armorStands.add(stand);
                         endLaser = true;
@@ -304,7 +305,7 @@ public class PlayerEditorManager implements Listener {
             List<Entity> nearby = (List<Entity>) player.getWorld().getNearbyEntities(eyeLaser, LASERRADIUS, LASERRADIUS, LASERRADIUS);
             if (!nearby.isEmpty()) {
                 boolean endLaser = false;
-                for ( Entity e : nearby) {
+                for (Entity e : nearby) {
                     if (e instanceof ItemFrame frame) {
                         itemFrames.add(frame);
                         endLaser = true;
@@ -321,7 +322,7 @@ public class PlayerEditorManager implements Listener {
     }
 
 
-    boolean canEdit( Player player,  Entity entity) {
+    boolean canEdit(Player player, Entity entity) {
         //Get the Entity being checked for editing
         Block block = entity.getLocation().getBlock();
 
@@ -329,43 +330,43 @@ public class PlayerEditorManager implements Listener {
         return protections.stream().allMatch(protection -> protection.checkPermission(block, player));
     }
 
-    void applyLeftTool( Player player,  ArmorStand as) {
+    void applyLeftTool(Player player, ArmorStand as) {
         getPlayerEditor(player.getUniqueId()).cancelOpenMenu();
         getPlayerEditor(player.getUniqueId()).editArmorStand(as);
     }
 
-    void applyLeftTool( Player player,  ItemFrame itemf) {
+    void applyLeftTool(Player player, ItemFrame itemf) {
         getPlayerEditor(player.getUniqueId()).cancelOpenMenu();
         getPlayerEditor(player.getUniqueId()).editItemFrame(itemf);
     }
 
-    void applyRightTool( Player player,  ItemFrame itemf) {
+    void applyRightTool(Player player, ItemFrame itemf) {
         getPlayerEditor(player.getUniqueId()).cancelOpenMenu();
         getPlayerEditor(player.getUniqueId()).editItemFrame(itemf);
     }
 
-    void applyRightTool( Player player,  ArmorStand as) {
+    void applyRightTool(Player player, ArmorStand as) {
         getPlayerEditor(player.getUniqueId()).cancelOpenMenu();
         getPlayerEditor(player.getUniqueId()).reverseEditArmorStand(as);
     }
 
     //Unused?
     @EventHandler(priority = EventPriority.LOWEST)
-    void onRightClickTool( PlayerInteractEvent e) {
+    void onRightClickTool(PlayerInteractEvent e) {
         if (!(e.getAction() == Action.LEFT_CLICK_AIR
-                || e.getAction() == Action.RIGHT_CLICK_AIR
-                || e.getAction() == Action.LEFT_CLICK_BLOCK
-                || e.getAction() == Action.RIGHT_CLICK_BLOCK)) return;
+            || e.getAction() == Action.RIGHT_CLICK_AIR
+            || e.getAction() == Action.LEFT_CLICK_BLOCK
+            || e.getAction() == Action.RIGHT_CLICK_BLOCK)) return;
         Player player = e.getPlayer();
         if (!plugin.isEditTool(player.getInventory().getItemInMainHand())) return;
         if (plugin.requireSneaking && !player.isSneaking()) return;
-        if(!player.hasPermission("asedit.basic")) return;
+        if (!player.hasPermission("asedit.basic")) return;
         e.setCancelled(true);
         getPlayerEditor(player.getUniqueId()).openMenu();
     }
 
     @EventHandler(priority = EventPriority.NORMAL)
-    void onScrollNCrouch( PlayerItemHeldEvent e) {
+    void onScrollNCrouch(PlayerItemHeldEvent e) {
         Player player = e.getPlayer();
         if (!player.isSneaking()) return;
         if (!plugin.isEditTool(player.getInventory().getItem(e.getPreviousSlot()))) return;
@@ -379,7 +380,7 @@ public class PlayerEditorManager implements Listener {
     }
 
     @EventHandler(priority = EventPriority.LOWEST)
-    void onPlayerMenuSelect( InventoryClickEvent e) {
+    void onPlayerMenuSelect(InventoryClickEvent e) {
         if (e.getInventory().getHolder() == null) return;
         if (!(e.getInventory().getHolder() instanceof ASEHolder)) return;
         if (e.getInventory().getHolder() == menuHolder) {
@@ -405,7 +406,7 @@ public class PlayerEditorManager implements Listener {
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-    void onPlayerMenuClose( InventoryCloseEvent e) {
+    void onPlayerMenuClose(InventoryCloseEvent e) {
         if (e.getInventory().getHolder() == null) return;
         if (!(e.getInventory().getHolder() instanceof ASEHolder)) return;
         if (e.getInventory().getHolder() == equipmentHolder) {
@@ -415,21 +416,21 @@ public class PlayerEditorManager implements Listener {
     }
 
     @EventHandler(priority = EventPriority.MONITOR)
-    void onPlayerLogOut( PlayerQuitEvent e) {
+    void onPlayerLogOut(PlayerQuitEvent e) {
         removePlayerEditor(e.getPlayer().getUniqueId());
     }
 
-    public PlayerEditor getPlayerEditor( UUID uuid) {
+    public PlayerEditor getPlayerEditor(UUID uuid) {
         return players.containsKey(uuid) ? players.get(uuid) : addPlayerEditor(uuid);
     }
 
-    PlayerEditor addPlayerEditor( UUID uuid) {
+    PlayerEditor addPlayerEditor(UUID uuid) {
         PlayerEditor pe = new PlayerEditor(uuid, plugin);
         players.put(uuid, pe);
         return pe;
     }
 
-    private void removePlayerEditor( UUID uuid) {
+    private void removePlayerEditor(UUID uuid) {
         players.remove(uuid);
     }
 
@@ -441,14 +442,20 @@ public class PlayerEditorManager implements Listener {
         return equipmentHolder;
     }
 
-    long getTime(){
+    long getTime() {
         return counter.ticks;
     }
 
-    class TickCounter implements Runnable{
+    class TickCounter implements Runnable {
         long ticks = 0; //I am optimistic
+
         @Override
-        public void run() {ticks++;}
-        public long getTime() {return ticks;}
+        public void run() {
+            ticks++;
+        }
+
+        public long getTime() {
+            return ticks;
+        }
     }
 }

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
@@ -274,8 +274,8 @@ public class PlayerEditorManager implements Listener {
             if (!nearby.isEmpty()) {
                 boolean endLaser = false;
                 for ( Entity e : nearby) {
-                    if (e instanceof ArmorStand) {
-                        armorStands.add((ArmorStand) e);
+                    if (e instanceof ArmorStand stand) {
+                        armorStands.add(stand);
                         endLaser = true;
                     }
                 }
@@ -305,8 +305,8 @@ public class PlayerEditorManager implements Listener {
             if (!nearby.isEmpty()) {
                 boolean endLaser = false;
                 for ( Entity e : nearby) {
-                    if (e instanceof ItemFrame) {
-                        itemFrames.add((ItemFrame) e);
+                    if (e instanceof ItemFrame frame) {
+                        itemFrames.add(frame);
                         endLaser = true;
                     }
                 }

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
@@ -20,7 +20,6 @@
 package io.github.rypofalem.armorstandeditor;
 
 import com.google.common.collect.ImmutableList;
-
 import io.github.rypofalem.armorstandeditor.api.ArmorStandRenameEvent;
 import io.github.rypofalem.armorstandeditor.api.ItemFrameGlowEvent;
 import io.github.rypofalem.armorstandeditor.menu.ASEHolder;
@@ -65,16 +64,16 @@ public class PlayerEditorManager implements Listener {
     // Instantiate protections used to determine whether a player may edit an armor stand or item frame
     //NOTE: GriefPreventionProtection is Depreciated as of v1.19.3-40
     private final List<Protection> protections = ImmutableList.of(
-        new GriefDefenderProtection(),
-        new GriefPreventionProtection(),
-        new LandsProtection(),
-        new PlotSquaredProtection(),
-        new SkyblockProtection(),
-        new TownyProtection(),
-        new WorldGuardProtection(),
-        new BentoBoxProtection());
+            new GriefDefenderProtection(),
+            new GriefPreventionProtection(),
+            new LandsProtection(),
+            new PlotSquaredProtection(),
+            new SkyblockProtection(),
+            new TownyProtection(),
+            new WorldGuardProtection(),
+            new BentoBoxProtection());
 
-    PlayerEditorManager(ArmorStandEditorPlugin plugin) {
+    PlayerEditorManager( ArmorStandEditorPlugin plugin) {
         this.plugin = plugin;
         players = new HashMap<>();
         coarseAdj = Util.FULL_CIRCLE / plugin.coarseRot;
@@ -86,7 +85,7 @@ public class PlayerEditorManager implements Listener {
     }
 
     @EventHandler(priority = EventPriority.LOWEST)
-    void onArmorStandDamage(EntityDamageByEntityEvent event) {
+    void onArmorStandDamage( EntityDamageByEntityEvent event) {
         if (!(event.getDamager() instanceof Player)) return;
         Player player = (Player) event.getDamager();
         if (!plugin.isEditTool(player.getInventory().getItemInMainHand())) return;
@@ -110,7 +109,7 @@ public class PlayerEditorManager implements Listener {
     }
 
     @EventHandler(priority = EventPriority.LOWEST)
-    void onArmorStandInteract(PlayerInteractAtEntityEvent event) {
+    void onArmorStandInteract( PlayerInteractAtEntityEvent event) {
         if (ignoreNextInteract) return;
         if (event.getHand() != EquipmentSlot.HAND) return;
         Player player = event.getPlayer();
@@ -181,8 +180,8 @@ public class PlayerEditorManager implements Listener {
             }
 
             if (player.getInventory().getItemInMainHand().getType().equals(Material.GLOW_INK_SAC) //attempt glowing
-                && player.hasPermission("asedit.basic")
-                && plugin.glowItemFrames && player.isSneaking()) {
+                    && player.hasPermission("asedit.basic")
+                    && plugin.glowItemFrames && player.isSneaking()) {
 
                 ItemFrameGlowEvent e = new ItemFrameGlowEvent(itemFrame, player);
                 Bukkit.getPluginManager().callEvent(e);
@@ -218,7 +217,7 @@ public class PlayerEditorManager implements Listener {
 
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     void onArmorStandBreak(EntityDamageByEntityEvent event) { // Fixes issue #309
-        if (!(event.getDamager() instanceof Player)) return; // If the damager is not a player, ignore.
+        if (!(event.getDamager() instanceof Player))     return; // If the damager is not a player, ignore.
         if (!(event.getEntity()  instanceof ArmorStand)) return; // If the damaged entity is not an ArmorStand, ignore.
 
         if (event.getEntity() instanceof ArmorStand entityAS) {
@@ -274,9 +273,9 @@ public class PlayerEditorManager implements Listener {
             List<Entity> nearby = (List<Entity>) player.getWorld().getNearbyEntities(eyeLaser, LASERRADIUS, LASERRADIUS, LASERRADIUS);
             if (!nearby.isEmpty()) {
                 boolean endLaser = false;
-                for (Entity e : nearby) {
-                    if (e instanceof ArmorStand stand) {
-                        armorStands.add(stand);
+                for ( Entity e : nearby) {
+                    if (e instanceof ArmorStand) {
+                        armorStands.add((ArmorStand) e);
                         endLaser = true;
                     }
                 }
@@ -305,9 +304,9 @@ public class PlayerEditorManager implements Listener {
             List<Entity> nearby = (List<Entity>) player.getWorld().getNearbyEntities(eyeLaser, LASERRADIUS, LASERRADIUS, LASERRADIUS);
             if (!nearby.isEmpty()) {
                 boolean endLaser = false;
-                for (Entity e : nearby) {
-                    if (e instanceof ItemFrame frame) {
-                        itemFrames.add(frame);
+                for ( Entity e : nearby) {
+                    if (e instanceof ItemFrame) {
+                        itemFrames.add((ItemFrame) e);
                         endLaser = true;
                     }
                 }
@@ -322,7 +321,7 @@ public class PlayerEditorManager implements Listener {
     }
 
 
-    boolean canEdit(Player player, Entity entity) {
+    boolean canEdit( Player player,  Entity entity) {
         //Get the Entity being checked for editing
         Block block = entity.getLocation().getBlock();
 
@@ -330,50 +329,43 @@ public class PlayerEditorManager implements Listener {
         return protections.stream().allMatch(protection -> protection.checkPermission(block, player));
     }
 
-    void applyLeftTool(Player player, ArmorStand as) {
+    void applyLeftTool( Player player,  ArmorStand as) {
         getPlayerEditor(player.getUniqueId()).cancelOpenMenu();
         getPlayerEditor(player.getUniqueId()).editArmorStand(as);
     }
 
-    void applyLeftTool(Player player, ItemFrame itemf) {
+    void applyLeftTool( Player player,  ItemFrame itemf) {
         getPlayerEditor(player.getUniqueId()).cancelOpenMenu();
         getPlayerEditor(player.getUniqueId()).editItemFrame(itemf);
     }
 
-    void applyRightTool(Player player, ItemFrame itemf) {
+    void applyRightTool( Player player,  ItemFrame itemf) {
         getPlayerEditor(player.getUniqueId()).cancelOpenMenu();
         getPlayerEditor(player.getUniqueId()).editItemFrame(itemf);
     }
 
-    void applyRightTool(Player player, ArmorStand as) {
+    void applyRightTool( Player player,  ArmorStand as) {
         getPlayerEditor(player.getUniqueId()).cancelOpenMenu();
         getPlayerEditor(player.getUniqueId()).reverseEditArmorStand(as);
     }
 
     //Unused?
     @EventHandler(priority = EventPriority.LOWEST)
-    void onRightClickTool(PlayerInteractEvent e) {
+    void onRightClickTool( PlayerInteractEvent e) {
         if (!(e.getAction() == Action.LEFT_CLICK_AIR
-            || e.getAction() == Action.RIGHT_CLICK_AIR
-            || e.getAction() == Action.LEFT_CLICK_BLOCK
-            || e.getAction() == Action.RIGHT_CLICK_BLOCK)) return;
+                || e.getAction() == Action.RIGHT_CLICK_AIR
+                || e.getAction() == Action.LEFT_CLICK_BLOCK
+                || e.getAction() == Action.RIGHT_CLICK_BLOCK)) return;
         Player player = e.getPlayer();
         if (!plugin.isEditTool(player.getInventory().getItemInMainHand())) return;
         if (plugin.requireSneaking && !player.isSneaking()) return;
-        if (!player.hasPermission("asedit.basic")) return;
-
-        if (!plugin.allowedWorldList.contains(player.getWorld().getName())) { //Implementation for Per World ASE
-            player.sendMessage("notincorrectworld", "warn");
-            e.setCancelled(true);
-            return;
-        }
-
+        if(!player.hasPermission("asedit.basic")) return;
         e.setCancelled(true);
         getPlayerEditor(player.getUniqueId()).openMenu();
     }
 
     @EventHandler(priority = EventPriority.NORMAL)
-    void onScrollNCrouch(PlayerItemHeldEvent e) {
+    void onScrollNCrouch( PlayerItemHeldEvent e) {
         Player player = e.getPlayer();
         if (!player.isSneaking()) return;
         if (!plugin.isEditTool(player.getInventory().getItem(e.getPreviousSlot()))) return;
@@ -387,7 +379,7 @@ public class PlayerEditorManager implements Listener {
     }
 
     @EventHandler(priority = EventPriority.LOWEST)
-    void onPlayerMenuSelect(InventoryClickEvent e) {
+    void onPlayerMenuSelect( InventoryClickEvent e) {
         if (e.getInventory().getHolder() == null) return;
         if (!(e.getInventory().getHolder() instanceof ASEHolder)) return;
         if (e.getInventory().getHolder() == menuHolder) {
@@ -413,7 +405,7 @@ public class PlayerEditorManager implements Listener {
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-    void onPlayerMenuClose(InventoryCloseEvent e) {
+    void onPlayerMenuClose( InventoryCloseEvent e) {
         if (e.getInventory().getHolder() == null) return;
         if (!(e.getInventory().getHolder() instanceof ASEHolder)) return;
         if (e.getInventory().getHolder() == equipmentHolder) {
@@ -423,21 +415,21 @@ public class PlayerEditorManager implements Listener {
     }
 
     @EventHandler(priority = EventPriority.MONITOR)
-    void onPlayerLogOut(PlayerQuitEvent e) {
+    void onPlayerLogOut( PlayerQuitEvent e) {
         removePlayerEditor(e.getPlayer().getUniqueId());
     }
 
-    public PlayerEditor getPlayerEditor(UUID uuid) {
+    public PlayerEditor getPlayerEditor( UUID uuid) {
         return players.containsKey(uuid) ? players.get(uuid) : addPlayerEditor(uuid);
     }
 
-    PlayerEditor addPlayerEditor(UUID uuid) {
+    PlayerEditor addPlayerEditor( UUID uuid) {
         PlayerEditor pe = new PlayerEditor(uuid, plugin);
         players.put(uuid, pe);
         return pe;
     }
 
-    private void removePlayerEditor(UUID uuid) {
+    private void removePlayerEditor( UUID uuid) {
         players.remove(uuid);
     }
 
@@ -449,20 +441,14 @@ public class PlayerEditorManager implements Listener {
         return equipmentHolder;
     }
 
-    long getTime() {
+    long getTime(){
         return counter.ticks;
     }
 
-    class TickCounter implements Runnable {
+    class TickCounter implements Runnable{
         long ticks = 0; //I am optimistic
-
         @Override
-        public void run() {
-            ticks++;
-        }
-
-        public long getTime() {
-            return ticks;
-        }
+        public void run() {ticks++;}
+        public long getTime() {return ticks;}
     }
 }

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
@@ -326,6 +326,11 @@ public class PlayerEditorManager implements Listener {
         //Get the Entity being checked for editing
         Block block = entity.getLocation().getBlock();
 
+        if (!plugin.allowedWorldList.contains(player.getWorld().getName())) { //Implementation for Per World ASE
+            getPlayerEditor(player.getUniqueId()).sendMessage("notincorrectworld", "warn");
+            return false;
+        }
+
         // Check if all protections allow this edit, if one fails, don't allow edit
         return protections.stream().allMatch(protection -> protection.checkPermission(block, player));
     }

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
@@ -233,6 +233,11 @@ public class PlayerEditorManager implements Listener {
                 }
             }
         }
+
+        if(event.getEntity() instanceof ArmorStand entityAS && entityAS.isDead()){
+            entityAS.setCustomName(null);
+            entityAS.setCustomNameVisible(false);
+        }
     }
 
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
@@ -363,7 +363,7 @@ public class PlayerEditorManager implements Listener {
         if (!player.hasPermission("asedit.basic")) return;
 
         if (!plugin.allowedWorldList.contains(player.getWorld().getName())) { //Implementation for Per World ASE
-            getPlayerEditor(player.getUniqueId()).sendMessage("notincorrectworld", "warn");
+            player.sendMessage("notincorrectworld", "warn");
             e.setCancelled(true);
             return;
         }

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
@@ -252,9 +252,8 @@ public class PlayerEditorManager implements Listener {
             getPlayerEditor(player.getUniqueId()).setTarget(as);
         } else if (itemF != null && !itemF.isEmpty()) {
             getPlayerEditor(player.getUniqueId()).setFrameTarget(itemF);
-        } else { //TODO: Fix the sending of the message Twice in this Statement
-            getPlayerEditor(player.getUniqueId()).setTarget(null);
-            getPlayerEditor(player.getUniqueId()).setFrameTarget(null);
+        } else {
+            getPlayerEditor(player.getUniqueId()).sendMessage("nodoubletarget","warn");
         }
     }
 
@@ -363,7 +362,7 @@ public class PlayerEditorManager implements Listener {
         if (!player.hasPermission("asedit.basic")) return;
 
         if (!plugin.allowedWorldList.contains(player.getWorld().getName())) { //Implementation for Per World ASE
-            player.sendMessage("notincorrectworld", "warn");
+            getPlayerEditor(player.getUniqueId()).sendMessage("notincorrectworld", "warn");
             e.setCancelled(true);
             return;
         }

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
@@ -38,6 +38,7 @@ import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.player.*;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.util.Vector;
 
@@ -235,8 +236,11 @@ public class PlayerEditorManager implements Listener {
         }
 
         if(event.getEntity() instanceof ArmorStand entityAS && entityAS.isDead()){
+            //TODO: Find a more permanent fix for "Once you destroy that armor stand, the armor stand will keep it's name and colour given by the name tag." THIS IS A TEMP SOLUTION FOR NOW.
             entityAS.setCustomName(null);
             entityAS.setCustomNameVisible(false);
+
+            event.setCancelled(false);
         }
     }
 

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
@@ -326,11 +326,6 @@ public class PlayerEditorManager implements Listener {
         //Get the Entity being checked for editing
         Block block = entity.getLocation().getBlock();
 
-        if (!plugin.allowedWorldList.contains(player.getWorld().getName())) { //Implementation for Per World ASE
-            getPlayerEditor(player.getUniqueId()).sendMessage("notincorrectworld", "warn");
-            return false;
-        }
-
         // Check if all protections allow this edit, if one fails, don't allow edit
         return protections.stream().allMatch(protection -> protection.checkPermission(block, player));
     }
@@ -366,6 +361,13 @@ public class PlayerEditorManager implements Listener {
         if (!plugin.isEditTool(player.getInventory().getItemInMainHand())) return;
         if (plugin.requireSneaking && !player.isSneaking()) return;
         if (!player.hasPermission("asedit.basic")) return;
+
+        if (!plugin.allowedWorldList.contains(player.getWorld().getName())) { //Implementation for Per World ASE
+            getPlayerEditor(player.getUniqueId()).sendMessage("notincorrectworld", "warn");
+            e.setCancelled(true);
+            return;
+        }
+
         e.setCancelled(true);
         getPlayerEditor(player.getUniqueId()).openMenu();
     }

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
@@ -216,6 +216,25 @@ public class PlayerEditorManager implements Listener {
     }
 
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    void onArmorStandBreak(EntityDamageByEntityEvent event) { // Fixes issue #309
+        if (!(event.getDamager() instanceof Player))     return; // If the damager is not a player, ignore.
+        if (!(event.getEntity()  instanceof ArmorStand)) return; // If the damaged entity is not an ArmorStand, ignore.
+
+        if (event.getEntity() instanceof ArmorStand entityAS) {
+            // Check if the ArmorStand is invulnerable and if the damager is a player.
+            if (entityAS.isInvulnerable() && event.getDamager() instanceof Player p) {
+                // Check if the player is in Creative mode.
+                if (p.getGameMode() == GameMode.CREATIVE) {
+                    // If the player is in Creative mode and the ArmorStand is invulnerable,
+                    // cancel the event to prevent breaking the ArmorStand.
+                    p.sendMessage(plugin.getLang().getMessage("unabledestroycreative"));
+                    event.setCancelled(true); // Cancel the event to prevent ArmorStand destruction.
+                }
+            }
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void onSwitchHands(PlayerSwapHandItemsEvent event) {
         if (!plugin.isEditTool(event.getOffHandItem())) return; //event assumes they are already switched
         event.setCancelled(true);

--- a/src/main/java/io/github/rypofalem/armorstandeditor/Scheduler.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/Scheduler.java
@@ -50,7 +50,8 @@ public class Scheduler {
         try {
             clazz.getDeclaredMethod(methodName, parameterTypes);
             return true;
-        } catch (Throwable ignored) {}
+        } catch (Throwable ignored) {
+        }
         return false;
     }
 
@@ -79,7 +80,7 @@ public class Scheduler {
         if (isFolia()) {
             Object globalRegionScheduler = getGlobalRegionScheduler();
             callMethod(globalRegionScheduler, "runAtFixedRate", new Class[]{Plugin.class, Consumer.class, long.class, long.class},
-                       plugin, (Consumer<?>) (task) -> runnable.run(), initialDelayTicks, periodTicks);
+                plugin, (Consumer<?>) (task) -> runnable.run(), initialDelayTicks, periodTicks);
             return;
         }
         Bukkit.getScheduler().runTaskTimerAsynchronously(plugin, runnable, initialDelayTicks, periodTicks);
@@ -89,7 +90,7 @@ public class Scheduler {
         if (isFolia()) {
             Object globalRegionScheduler = getGlobalRegionScheduler();
             callMethod(globalRegionScheduler, "runDelayed", new Class[]{Plugin.class, Consumer.class, long.class},
-                       plugin, (Consumer<?>) (task) -> runnable.run(), delayedTicks);
+                plugin, (Consumer<?>) (task) -> runnable.run(), delayedTicks);
             return;
         }
         Bukkit.getScheduler().runTaskLater(plugin, runnable, delayedTicks);

--- a/src/main/java/io/github/rypofalem/armorstandeditor/Util.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/Util.java
@@ -21,20 +21,20 @@ package io.github.rypofalem.armorstandeditor;
 
 public abstract class Util {
 
-    public static final double FULL_CIRCLE = Math.PI*2;
+    public static final double FULL_CIRCLE = Math.PI * 2;
 
-    public static <T extends Enum<?>> String getEnumList(Class<T> enumType){
+    public static <T extends Enum<?>> String getEnumList(Class<T> enumType) {
         return getEnumList(enumType, " | ");
     }
 
-    public static <T extends Enum<?>> String getEnumList(Class<T> enumType, String delimiter){
+    public static <T extends Enum<?>> String getEnumList(Class<T> enumType, String delimiter) {
         StringBuilder list = new StringBuilder();
-        boolean put =false;
-        for(Enum<?> e : enumType.getEnumConstants()){
+        boolean put = false;
+        for (Enum<?> e : enumType.getEnumConstants()) {
             list.append(e.toString()).append(delimiter);
             put = true;
         }
-        if(put) list = new StringBuilder(list.substring(0, list.length() - delimiter.length()));
+        if (put) list = new StringBuilder(list.substring(0, list.length() - delimiter.length()));
         return list.toString();
     }
 
@@ -44,23 +44,23 @@ public abstract class Util {
         return current;
     }
 
-    public static double subAngle(double current, double angleChange){
+    public static double subAngle(double current, double angleChange) {
         current -= angleChange;
         current = fixAngle(current, angleChange);
         return current;
     }
 
     //clamps angle to 0 if it exceeds 2PI rad (360 degrees), is closer to 0 than angleChange value, or is closer to 2PI rad than 2PI rad - angleChange value.
-    private static double fixAngle(double angle, double angleChange){
-        if(angle > FULL_CIRCLE){
+    private static double fixAngle(double angle, double angleChange) {
+        if (angle > FULL_CIRCLE) {
             return 0;
         }
 
-        if(angle > 0 && angle < angleChange && angle < angleChange/2){
+        if (angle > 0 && angle < angleChange && angle < angleChange / 2) {
             return 0;
         }
 
-        if(angle > FULL_CIRCLE -angle && angle > FULL_CIRCLE - (angleChange/2)){
+        if (angle > FULL_CIRCLE - angle && angle > FULL_CIRCLE - (angleChange / 2)) {
             return 0;
         }
 

--- a/src/main/java/io/github/rypofalem/armorstandeditor/api/ArmorStandEvent.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/api/ArmorStandEvent.java
@@ -20,16 +20,17 @@
 package io.github.rypofalem.armorstandeditor.api;
 
 import lombok.Getter;
+
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.event.Event;
 
-public abstract class ArmorStandEvent extends Event{
+public abstract class ArmorStandEvent extends Event {
 
-	@Getter
-	protected final ArmorStand armorStand;
+    @Getter
+    protected final ArmorStand armorStand;
 
-	public ArmorStandEvent(ArmorStand armorStand) {
-		this.armorStand = armorStand;
-	}
+    public ArmorStandEvent(ArmorStand armorStand) {
+        this.armorStand = armorStand;
+    }
 
 }

--- a/src/main/java/io/github/rypofalem/armorstandeditor/api/ArmorStandManipulatedEvent.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/api/ArmorStandManipulatedEvent.java
@@ -20,6 +20,7 @@ package io.github.rypofalem.armorstandeditor.api;
 
 import lombok.Getter;
 import lombok.Setter;
+
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
@@ -27,19 +28,27 @@ import org.bukkit.event.HandlerList;
 
 public class ArmorStandManipulatedEvent extends ArmorStandEvent implements Cancellable {
 
-	@Getter @Setter
-	private boolean cancelled = false;
+    @Getter
+    @Setter
+    private boolean cancelled = false;
 
-	@Getter
-	protected final Player player;
+    @Getter
+    protected final Player player;
 
-	public ArmorStandManipulatedEvent(ArmorStand armorStand, Player player) {
-		super(armorStand);
-		this.player = player;
-	}
+    public ArmorStandManipulatedEvent(ArmorStand armorStand, Player player) {
+        super(armorStand);
+        this.player = player;
+    }
 
-	/* Generated for Bukkit */
-	private static final HandlerList handlers = new HandlerList();
-	public static HandlerList getHandlerList() { return (handlers); }
-	@Override public HandlerList getHandlers() { return (handlers); }
+    /* Generated for Bukkit */
+    private static final HandlerList handlers = new HandlerList();
+
+    public static HandlerList getHandlerList() {
+        return (handlers);
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return (handlers);
+    }
 }

--- a/src/main/java/io/github/rypofalem/armorstandeditor/api/ArmorStandRenameEvent.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/api/ArmorStandRenameEvent.java
@@ -20,6 +20,7 @@ package io.github.rypofalem.armorstandeditor.api;
 
 import lombok.Getter;
 import lombok.Setter;
+
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
@@ -27,23 +28,32 @@ import org.bukkit.event.HandlerList;
 
 public class ArmorStandRenameEvent extends ArmorStandEvent implements Cancellable {
 
-	@Getter @Setter
-	private boolean cancelled = false;
-	@Getter @Setter
-	protected String name;
+    @Getter
+    @Setter
+    private boolean cancelled = false;
+    @Getter
+    @Setter
+    protected String name;
 
-	@Getter
-	protected final Player player;
+    @Getter
+    protected final Player player;
 
-	public ArmorStandRenameEvent(ArmorStand armorStand, Player player, String name) {
-		super(armorStand);
-		this.player = player;
-		this.name = name;
-	}
+    public ArmorStandRenameEvent(ArmorStand armorStand, Player player, String name) {
+        super(armorStand);
+        this.player = player;
+        this.name = name;
+    }
 
-	/* Generated for Bukkit */
-	private static final HandlerList handlers = new HandlerList();
-	public static HandlerList getHandlerList() { return (handlers); }
-	@Override public HandlerList getHandlers() { return (handlers); }
+    /* Generated for Bukkit */
+    private static final HandlerList handlers = new HandlerList();
+
+    public static HandlerList getHandlerList() {
+        return (handlers);
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return (handlers);
+    }
 
 }

--- a/src/main/java/io/github/rypofalem/armorstandeditor/api/ArmorStandTargetedEvent.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/api/ArmorStandTargetedEvent.java
@@ -21,25 +21,34 @@ package io.github.rypofalem.armorstandeditor.api;
 
 import lombok.Getter;
 import lombok.Setter;
+
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 
 public class ArmorStandTargetedEvent extends ArmorStandEvent implements Cancellable {
-	@Getter @Setter
-	private boolean cancelled = false;
+    @Getter
+    @Setter
+    private boolean cancelled = false;
 
-	@Getter
-	protected final Player player;
+    @Getter
+    protected final Player player;
 
-	public ArmorStandTargetedEvent(ArmorStand armorStand, Player player) {
-		super(armorStand);
-		this.player = player;
-	}
+    public ArmorStandTargetedEvent(ArmorStand armorStand, Player player) {
+        super(armorStand);
+        this.player = player;
+    }
 
-	/* Generated for Bukkit */
-	private static final HandlerList handlers = new HandlerList();
-	public static HandlerList getHandlerList() { return (handlers); }
-	@Override public HandlerList getHandlers() { return (handlers); }
+    /* Generated for Bukkit */
+    private static final HandlerList handlers = new HandlerList();
+
+    public static HandlerList getHandlerList() {
+        return (handlers);
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return (handlers);
+    }
 }

--- a/src/main/java/io/github/rypofalem/armorstandeditor/api/ItemFrameEvent.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/api/ItemFrameEvent.java
@@ -20,16 +20,17 @@
 package io.github.rypofalem.armorstandeditor.api;
 
 import lombok.Getter;
+
 import org.bukkit.entity.ItemFrame;
 import org.bukkit.event.Event;
 
-public abstract class ItemFrameEvent extends Event{
+public abstract class ItemFrameEvent extends Event {
 
-	@Getter
-	protected final ItemFrame itemFrame;
+    @Getter
+    protected final ItemFrame itemFrame;
 
-	public ItemFrameEvent(ItemFrame itemFrame) {
-		this.itemFrame = itemFrame;
-	}
+    public ItemFrameEvent(ItemFrame itemFrame) {
+        this.itemFrame = itemFrame;
+    }
 
 }

--- a/src/main/java/io/github/rypofalem/armorstandeditor/api/ItemFrameGlowEvent.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/api/ItemFrameGlowEvent.java
@@ -2,25 +2,34 @@ package io.github.rypofalem.armorstandeditor.api;
 
 import lombok.Getter;
 import lombok.Setter;
+
 import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 
 public class ItemFrameGlowEvent extends ItemFrameEvent implements Cancellable {
-	@Getter @Setter
-	private boolean cancelled = false;
+    @Getter
+    @Setter
+    private boolean cancelled = false;
 
-	@Getter
-	protected final Player player;
+    @Getter
+    protected final Player player;
 
-	public ItemFrameGlowEvent(ItemFrame itemFrame, Player player) {
-		super(itemFrame);
-		this.player = player;
-	}
+    public ItemFrameGlowEvent(ItemFrame itemFrame, Player player) {
+        super(itemFrame);
+        this.player = player;
+    }
 
-	/* Generated for Bukkit */
-	private static final HandlerList handlers = new HandlerList();
-	public static HandlerList getHandlerList() { return (handlers); }
-	@Override public HandlerList getHandlers() { return (handlers); }
+    /* Generated for Bukkit */
+    private static final HandlerList handlers = new HandlerList();
+
+    public static HandlerList getHandlerList() {
+        return (handlers);
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return (handlers);
+    }
 }

--- a/src/main/java/io/github/rypofalem/armorstandeditor/api/ItemFrameManipulatedEvent.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/api/ItemFrameManipulatedEvent.java
@@ -20,6 +20,7 @@ package io.github.rypofalem.armorstandeditor.api;
 
 import lombok.Getter;
 import lombok.Setter;
+
 import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
@@ -27,20 +28,28 @@ import org.bukkit.event.HandlerList;
 
 public class ItemFrameManipulatedEvent extends ItemFrameEvent implements Cancellable {
 
-	@Getter @Setter
-	private boolean cancelled = false;
+    @Getter
+    @Setter
+    private boolean cancelled = false;
 
-	@Getter
-	protected final Player player;
+    @Getter
+    protected final Player player;
 
-	public ItemFrameManipulatedEvent(ItemFrame itemFrame, Player player) {
-		super(itemFrame);
-		this.player = player;
-	}
+    public ItemFrameManipulatedEvent(ItemFrame itemFrame, Player player) {
+        super(itemFrame);
+        this.player = player;
+    }
 
-	/* Generated for Bukkit */
-	private static final HandlerList handlers = new HandlerList();
-	public static HandlerList getHandlerList() { return (handlers); }
-	@Override public HandlerList getHandlers() { return (handlers); }
+    /* Generated for Bukkit */
+    private static final HandlerList handlers = new HandlerList();
+
+    public static HandlerList getHandlerList() {
+        return (handlers);
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return (handlers);
+    }
 }
 

--- a/src/main/java/io/github/rypofalem/armorstandeditor/api/ItemFrameTargetedEvent.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/api/ItemFrameTargetedEvent.java
@@ -21,25 +21,34 @@ package io.github.rypofalem.armorstandeditor.api;
 
 import lombok.Getter;
 import lombok.Setter;
+
 import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 
 public class ItemFrameTargetedEvent extends ItemFrameEvent implements Cancellable {
-	@Getter @Setter
-	private boolean cancelled = false;
+    @Getter
+    @Setter
+    private boolean cancelled = false;
 
-	@Getter
-	protected final Player player;
+    @Getter
+    protected final Player player;
 
-	public ItemFrameTargetedEvent(ItemFrame itemFrame, Player player) {
-		super(itemFrame);
-		this.player = player;
-	}
+    public ItemFrameTargetedEvent(ItemFrame itemFrame, Player player) {
+        super(itemFrame);
+        this.player = player;
+    }
 
-	/* Generated for Bukkit */
-	private static final HandlerList handlers = new HandlerList();
-	public static HandlerList getHandlerList() { return (handlers); }
-	@Override public HandlerList getHandlers() { return (handlers); }
+    /* Generated for Bukkit */
+    private static final HandlerList handlers = new HandlerList();
+
+    public static HandlerList getHandlerList() {
+        return (handlers);
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return (handlers);
+    }
 }

--- a/src/main/java/io/github/rypofalem/armorstandeditor/api/PlayerOpenMenuEvent.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/api/PlayerOpenMenuEvent.java
@@ -20,25 +20,33 @@ package io.github.rypofalem.armorstandeditor.api;
 
 import lombok.Getter;
 import lombok.Setter;
+
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
 public class PlayerOpenMenuEvent extends Event implements Cancellable {
-	@Getter
-	@Setter
-	private boolean cancelled = false;
+    @Getter
+    @Setter
+    private boolean cancelled = false;
 
-	@Getter
-	protected final Player player;
+    @Getter
+    protected final Player player;
 
-	public PlayerOpenMenuEvent(Player player) {
-		this.player = player;
-	}
+    public PlayerOpenMenuEvent(Player player) {
+        this.player = player;
+    }
 
-	/* Generated for Bukkit */
-	private static final HandlerList handlers = new HandlerList();
-	public static HandlerList getHandlerList() { return (handlers); }
-	@Override public HandlerList getHandlers() { return (handlers); }
+    /* Generated for Bukkit */
+    private static final HandlerList handlers = new HandlerList();
+
+    public static HandlerList getHandlerList() {
+        return (handlers);
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return (handlers);
+    }
 }

--- a/src/main/java/io/github/rypofalem/armorstandeditor/language/Language.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/language/Language.java
@@ -119,7 +119,7 @@ public class Language {
                 default: color = !code.isColor() ? color : code;
             }
         }
-        return String.format("{\"text\":\"%s\", \"color\":\"%s\"%s%s%s%s%s}", message, color.name().toLowerCase(),
+        return "{\"text\":\"%s\", \"color\":\"%s\"%s%s%s%s%s}".formatted(message, color.name().toLowerCase(),
             obfuscated, bold, strikethrough, underlined, italic);
     }
 

--- a/src/main/java/io/github/rypofalem/armorstandeditor/language/Language.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/language/Language.java
@@ -21,15 +21,11 @@
 package io.github.rypofalem.armorstandeditor.language;
 
 import io.github.rypofalem.armorstandeditor.ArmorStandEditorPlugin;
+
 import org.bukkit.ChatColor;
 import org.bukkit.configuration.file.YamlConfiguration;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
 
 public class Language {
@@ -93,14 +89,14 @@ public class Language {
         return getMessage(path, "info");
     }
 
-    public String getRawMessage(String path, String format, String option){
+    public String getRawMessage(String path, String format, String option) {
         String message = ChatColor.stripColor(getMessage(path, format, option));
         format = getFormat(format);
         ChatColor color = ChatColor.WHITE;
         String bold = "" , italic = "" , underlined = "" , obfuscated = "" , strikethrough = "";
-        for(int i = 0; i < format.length(); i++){
+        for (int i = 0; i < format.length(); i++) {
             ChatColor code = ChatColor.getByChar(format.charAt(i));
-            switch(code) {
+            switch (code) {
                 case MAGIC:
                     obfuscated = ", \"obfuscated\": true";
                     break;
@@ -123,7 +119,7 @@ public class Language {
             obfuscated, bold, strikethrough, underlined, italic);
     }
 
-    private String getFormat(String format){
+    private String getFormat(String format) {
         format = getString(format);
         return format == null ? "" : format;
     }

--- a/src/main/java/io/github/rypofalem/armorstandeditor/menu/ASEHolder.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/menu/ASEHolder.java
@@ -25,9 +25,9 @@ import org.bukkit.inventory.InventoryHolder;
 
 public class ASEHolder implements InventoryHolder {
 
-	@Override
-	public Inventory getInventory() {
-		return null;
-	}
+    @Override
+    public Inventory getInventory() {
+        return null;
+    }
 
 }

--- a/src/main/java/io/github/rypofalem/armorstandeditor/menu/EquipmentMenu.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/menu/EquipmentMenu.java
@@ -20,6 +20,7 @@
 package io.github.rypofalem.armorstandeditor.menu;
 
 import io.github.rypofalem.armorstandeditor.PlayerEditor;
+
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.ArmorStand;
@@ -39,14 +40,14 @@ public class EquipmentMenu {
     static String name = "ArmorStand Equipment";
     ItemStack helmet, chest, pants, feetsies, rightHand, leftHand;
 
-    public EquipmentMenu(PlayerEditor pe, ArmorStand as){
+    public EquipmentMenu(PlayerEditor pe, ArmorStand as) {
         this.pe = pe;
         this.armorstand = as;
         name = pe.plugin.getLang().getMessage("equiptitle", "menutitle");
         menuInv = Bukkit.createInventory(pe.getManager().getEquipmentHolder(), 18, name);
     }
 
-    private void fillInventory(){
+    private void fillInventory() {
         menuInv.clear();
         EntityEquipment equipment = armorstand.getEquipment();
         assert equipment != null;
@@ -71,13 +72,13 @@ public class EquipmentMenu {
         ItemStack rightHandIcon = createIcon(Material.WOODEN_SWORD, "rhand");
         ItemStack leftHandIcon = createIcon(Material.SHIELD, "lhand");
         ItemStack[] items =
-                { helmetIcon, chestIcon, pantsIcon, feetsiesIcon, rightHandIcon, leftHandIcon, disabledIcon, disabledIcon, disabledIcon,
-                        helmet, chest, pants, feetsies, rightHand, leftHand, disabledIcon, disabledIcon, disabledIcon
-                };
+            {helmetIcon, chestIcon, pantsIcon, feetsiesIcon, rightHandIcon, leftHandIcon, disabledIcon, disabledIcon, disabledIcon,
+                helmet, chest, pants, feetsies, rightHand, leftHand, disabledIcon, disabledIcon, disabledIcon
+            };
         menuInv.setContents(items);
     }
 
-    private ItemStack createIcon(Material mat, String slot){
+    private ItemStack createIcon(Material mat, String slot) {
         ItemStack icon = new ItemStack(mat);
         ItemMeta meta = icon.getItemMeta();
         meta.getPersistentDataContainer().set(pe.plugin.getIconKey(), PersistentDataType.STRING, "ase icon");
@@ -91,12 +92,12 @@ public class EquipmentMenu {
         return icon;
     }
 
-    public void open(){
+    public void open() {
         fillInventory();
         pe.getPlayer().openInventory(menuInv);
     }
 
-    public void equipArmorstand(){
+    public void equipArmorstand() {
         helmet = menuInv.getItem(9);
         chest = menuInv.getItem(10);
         pants = menuInv.getItem(11);
@@ -111,7 +112,7 @@ public class EquipmentMenu {
         armorstand.getEquipment().setItemInOffHand(leftHand);
     }
 
-    public static String getName(){
+    public static String getName() {
         return name;
     }
 }

--- a/src/main/java/io/github/rypofalem/armorstandeditor/menu/Menu.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/menu/Menu.java
@@ -76,6 +76,7 @@ public class Menu {
         ItemStack slot4 = null;
         ItemStack help;
         ItemStack itemFrameVisible;
+        ItemStack blankSlot;
 
         //Variables that need to be Initialized
         ItemStack place = null;
@@ -85,34 +86,41 @@ public class Menu {
         ItemStack playerHead = null;
         ItemStack toggleVulnerabilty = null;
 
-        xAxis = createIcon(new ItemStack(Material.RED_WOOL, 1),
+        //Slots with No Value
+        blankSlot = createIcon(new ItemStack(Material.BLACK_STAINED_GLASS_PANE, 1), "", "");
+
+        //Axis - X, Y, Z for Movement
+        xAxis = createIcon(new ItemStack(Material.RED_CONCRETE, 1),
             "xaxis", "axis x");
 
-        yAxis = createIcon(new ItemStack(Material.GREEN_WOOL, 1),
+        yAxis = createIcon(new ItemStack(Material.GREEN_CONCRETE, 1),
             "yaxis", "axis y");
 
-        zAxis = createIcon(new ItemStack(Material.BLUE_WOOL, 1),
+        zAxis = createIcon(new ItemStack(Material.BLUE_CONCRETE, 1),
             "zaxis", "axis z");
 
-        coarseAdj = createIcon(new ItemStack(Material.DIRT, 1),
+        //Movement Speed
+        coarseAdj = createIcon(new ItemStack(Material.COARSE_DIRT, 1),
             "coarseadj", "adj coarse");
 
-        fineAdj = createIcon(new ItemStack(Material.SANDSTONE),
+        fineAdj = createIcon(new ItemStack(Material.SMOOTH_SANDSTONE),
             "fineadj", "adj fine");
 
-        reset = createIcon(new ItemStack(Material.LEVER),
+        //Reset Changes
+        reset = createIcon(new ItemStack(Material.WATER_BUCKET),
             "reset", "mode reset");
 
-        headPos = createIcon(new ItemStack(Material.LEATHER_HELMET),
+        //Which Part to Move
+        headPos = createIcon(new ItemStack(Material.IRON_HELMET),
             "head", "mode head");
 
-        bodyPos = createIcon(new ItemStack(Material.LEATHER_CHESTPLATE),
+        bodyPos = createIcon(new ItemStack(Material.IRON_CHESTPLATE),
             "body", "mode body");
 
-        leftLegPos = createIcon(new ItemStack(Material.LEATHER_LEGGINGS),
+        leftLegPos = createIcon(new ItemStack(Material.IRON_LEGGINGS),
             "leftleg", "mode leftleg");
 
-        rightLegPos = createIcon(new ItemStack(Material.LEATHER_LEGGINGS),
+        rightLegPos = createIcon(new ItemStack(Material.IRON_LEGGINGS),
             "rightleg", "mode rightleg");
 
         leftArmPos = createIcon(new ItemStack(Material.STICK),
@@ -129,9 +137,10 @@ public class Menu {
             pe.plugin.getArmorStandVisibility()) {
             visibility = new ItemStack(Material.POTION, 1);
             PotionMeta potionMeta = (PotionMeta) visibility.getItemMeta();
-            PotionEffect eff1 = new PotionEffect(PotionEffectType.INVISIBILITY, 1, 0);
-            assert potionMeta != null;
-            potionMeta.addCustomEffect(eff1, true);
+            PotionEffect effect = new PotionEffect(PotionEffectType.INVISIBILITY, 1, 0);
+            if (potionMeta != null) {
+                potionMeta.addCustomEffect(effect, true);
+            }
             visibility.setItemMeta(potionMeta);
             createIcon(visibility, "invisible", "mode invisible");
         } else {
@@ -149,7 +158,7 @@ public class Menu {
         //Praise end
 
         if (pe.getPlayer().hasPermission("asedit.toggleInvulnerability")) {
-            toggleVulnerabilty = createIcon(new ItemStack(Material.BEDROCK, 1),
+            toggleVulnerabilty = createIcon(new ItemStack(Material.TOTEM_OF_UNDYING, 1),
                 "vulnerability", "mode vulnerability");
         }
 
@@ -166,12 +175,12 @@ public class Menu {
         }
 
         if (pe.getPlayer().hasPermission("asedit.togglebaseplate")) {
-            plate = createIcon(new ItemStack(Material.STONE_SLAB, 1),
+            plate = createIcon(new ItemStack(Material.SMOOTH_STONE_SLAB, 1),
                 "baseplate", "mode baseplate");
         }
 
         if (pe.getPlayer().hasPermission("asedit.movement")) {
-            place = createIcon(new ItemStack(Material.MINECART, 1),
+            place = createIcon(new ItemStack(Material.RAIL, 1),
                 "placement", "mode placement");
         }
 
@@ -186,24 +195,24 @@ public class Menu {
         }
 
         if (pe.getPlayer().hasPermission("asedit.copy")) {
-            copy = createIcon(new ItemStack(Material.WRITABLE_BOOK),
+            copy = createIcon(new ItemStack(Material.FLOWER_BANNER_PATTERN),
                 "copy", "mode copy");
 
-            slot1 = createIcon(new ItemStack(Material.DANDELION),
+            slot1 = createIcon(new ItemStack(Material.BOOK),
                 "copyslot", "slot 1", "1");
 
-            slot2 = createIcon(new ItemStack(Material.AZURE_BLUET, 2),
+            slot2 = createIcon(new ItemStack(Material.BOOK, 2),
                 "copyslot", "slot 2", "2");
 
-            slot3 = createIcon(new ItemStack(Material.BLUE_ORCHID, 3),
+            slot3 = createIcon(new ItemStack(Material.BOOK, 3),
                 "copyslot", "slot 3", "3");
 
-            slot4 = createIcon(new ItemStack(Material.PEONY, 4),
+            slot4 = createIcon(new ItemStack(Material.BOOK, 4),
                 "copyslot", "slot 4", "4");
         }
 
         if (pe.getPlayer().hasPermission("asedit.paste")) {
-            paste = createIcon(new ItemStack(Material.ENCHANTED_BOOK),
+            paste = createIcon(new ItemStack(Material.FEATHER),
                 "paste", "mode paste");
         }
 
@@ -211,10 +220,13 @@ public class Menu {
             playerHead = createIcon(new ItemStack(Material.PLAYER_HEAD, 1),
                 "playerheadmenu",
                 "playerhead");
+        } else{
+            playerHead = blankSlot;
         }
 
         help = createIcon(new ItemStack(Material.NETHER_STAR), "helpgui", "help");
 
+/*
         ItemStack[] items =
             {
                 xAxis, yAxis, zAxis, null, coarseAdj, fineAdj, null, rotate, place,
@@ -224,6 +236,17 @@ public class Menu {
                 null, copy, paste, null, null, null, null, itemFrameVisible, null,
                 slot1, slot2, slot3, slot4, null, null, null, null, help
             };
+*/
+
+        ItemStack[] items = {
+                blankSlot, blankSlot, blankSlot, xAxis, yAxis, zAxis, blankSlot, blankSlot, help,
+                copy, paste, blankSlot, playerHead, headPos, reset, blankSlot, itemFrameVisible, blankSlot,
+                slot1, slot2, blankSlot, rightArmPos, bodyPos, leftArmPos, blankSlot, rotate, place,
+                slot3, slot4, blankSlot, rightLegPos, equipment, leftLegPos, blankSlot, coarseAdj, fineAdj,
+                blankSlot, blankSlot, blankSlot, blankSlot, blankSlot, blankSlot, blankSlot, blankSlot, blankSlot,
+                blankSlot, showArms, visibility, size, gravity, plate, toggleVulnerabilty, disableSlots, blankSlot
+        };
+
         menuInv.setContents(items);
     }
 

--- a/src/main/java/io/github/rypofalem/armorstandeditor/menu/Menu.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/menu/Menu.java
@@ -66,6 +66,7 @@ public class Menu {
         ItemStack visibility;
         ItemStack size = null;
         ItemStack rightLegPos;
+        ItemStack glowing;
         ItemStack leftLegPos;
         ItemStack plate = null;
         ItemStack copy = null;
@@ -225,26 +226,23 @@ public class Menu {
             playerHead = blankSlot;
         }
 
+        if (pe.getPlayer().hasPermission("asedit.togglearmorstandglow")){
+            glowing = createIcon(new ItemStack(Material.GLOW_INK_SAC, 1),
+                    "armorstandglow",
+                    "mode armorstandglow");
+        } else{
+            glowing = blankSlot;
+        }
+
         help = createIcon(new ItemStack(Material.NETHER_STAR), "helpgui", "help");
 
-/*
-        ItemStack[] items =
-            {
-                xAxis, yAxis, zAxis, null, coarseAdj, fineAdj, null, rotate, place,
-                null, headPos, playerHead, null, null, null, null, null, null,
-                rightArmPos, bodyPos, leftArmPos, reset, null, null, showArms, visibility, size,
-                rightLegPos, equipment, leftLegPos, null, null, toggleVulnerabilty, disableSlots, gravity, plate,
-                null, copy, paste, null, null, null, null, itemFrameVisible, null,
-                slot1, slot2, slot3, slot4, null, null, null, null, help
-            };
-*/
 
         ItemStack[] items = {
                 blankSlot, blankSlot, blankSlot, xAxis, yAxis, zAxis, blankSlot, blankSlot, help,
                 copy, paste, blankSlot, playerHead, headPos, reset, blankSlot, itemFrameVisible, blankSlot,
                 slot1, slot2, blankSlot, rightArmPos, bodyPos, leftArmPos, blankSlot, rotate, place,
                 slot3, slot4, blankSlot, rightLegPos, equipment, leftLegPos, blankSlot, coarseAdj, fineAdj,
-                blankSlot, blankSlot, blankSlot, blankSlot, blankSlot, blankSlot, blankSlot, blankSlot, blankSlot,
+                blankSlot, glowing, blankSlot, blankSlot, blankSlot, blankSlot, blankSlot, blankSlot, blankSlot,
                 blankSlot, showArms, visibility, size, gravity, plate, toggleVulnerabilty, disableSlots, blankSlot
         };
 

--- a/src/main/java/io/github/rypofalem/armorstandeditor/menu/Menu.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/menu/Menu.java
@@ -87,7 +87,8 @@ public class Menu {
         ItemStack toggleVulnerabilty = null;
 
         //Slots with No Value
-        blankSlot = createIcon(new ItemStack(Material.BLACK_STAINED_GLASS_PANE, 1), "", "");
+        blankSlot = createIcon(new ItemStack(Material.BLACK_STAINED_GLASS_PANE, 1),
+                "blankslot", "");
 
         //Axis - X, Y, Z for Movement
         xAxis = createIcon(new ItemStack(Material.RED_CONCRETE, 1),

--- a/src/main/java/io/github/rypofalem/armorstandeditor/menu/Menu.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/menu/Menu.java
@@ -21,6 +21,7 @@ package io.github.rypofalem.armorstandeditor.menu;
 
 import io.github.rypofalem.armorstandeditor.ArmorStandEditorPlugin;
 import io.github.rypofalem.armorstandeditor.PlayerEditor;
+
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.inventory.Inventory;
@@ -85,47 +86,47 @@ public class Menu {
         ItemStack toggleVulnerabilty = null;
 
         xAxis = createIcon(new ItemStack(Material.RED_WOOL, 1),
-                "xaxis", "axis x");
+            "xaxis", "axis x");
 
         yAxis = createIcon(new ItemStack(Material.GREEN_WOOL, 1),
-                "yaxis", "axis y");
+            "yaxis", "axis y");
 
         zAxis = createIcon(new ItemStack(Material.BLUE_WOOL, 1),
-                "zaxis", "axis z");
+            "zaxis", "axis z");
 
         coarseAdj = createIcon(new ItemStack(Material.DIRT, 1),
-                "coarseadj", "adj coarse");
+            "coarseadj", "adj coarse");
 
         fineAdj = createIcon(new ItemStack(Material.SANDSTONE),
-                "fineadj", "adj fine");
+            "fineadj", "adj fine");
 
         reset = createIcon(new ItemStack(Material.LEVER),
-                "reset", "mode reset");
+            "reset", "mode reset");
 
         headPos = createIcon(new ItemStack(Material.LEATHER_HELMET),
-                "head", "mode head");
+            "head", "mode head");
 
         bodyPos = createIcon(new ItemStack(Material.LEATHER_CHESTPLATE),
-                "body", "mode body");
+            "body", "mode body");
 
         leftLegPos = createIcon(new ItemStack(Material.LEATHER_LEGGINGS),
-                "leftleg", "mode leftleg");
+            "leftleg", "mode leftleg");
 
         rightLegPos = createIcon(new ItemStack(Material.LEATHER_LEGGINGS),
-                "rightleg", "mode rightleg");
+            "rightleg", "mode rightleg");
 
         leftArmPos = createIcon(new ItemStack(Material.STICK),
-                "leftarm", "mode leftarm");
+            "leftarm", "mode leftarm");
 
         rightArmPos = createIcon(new ItemStack(Material.STICK),
-                "rightarm", "mode rightarm");
+            "rightarm", "mode rightarm");
 
         showArms = createIcon(new ItemStack(Material.STICK),
-                "showarms", "mode showarms");
+            "showarms", "mode showarms");
 
         //Praise Start - Sikatsu and cowgod, Nicely spotted this being broken
         if (pe.getPlayer().hasPermission("asedit.togglearmorstandvisibility") ||
-                pe.plugin.getArmorStandVisibility()) {
+            pe.plugin.getArmorStandVisibility()) {
             visibility = new ItemStack(Material.POTION, 1);
             PotionMeta potionMeta = (PotionMeta) visibility.getItemMeta();
             PotionEffect eff1 = new PotionEffect(PotionEffectType.INVISIBILITY, 1, 0);
@@ -138,7 +139,7 @@ public class Menu {
         }
 
         if (pe.getPlayer().hasPermission("asedit.toggleitemframevisibility") ||
-                pe.plugin.getItemFrameVisibility()) {
+            pe.plugin.getItemFrameVisibility()) {
             itemFrameVisible = new ItemStack(Material.ITEM_FRAME, 1);
             createIcon(itemFrameVisible, "itemframevisible", "mode itemframe");
         } else {
@@ -149,12 +150,12 @@ public class Menu {
 
         if (pe.getPlayer().hasPermission("asedit.toggleInvulnerability")) {
             toggleVulnerabilty = createIcon(new ItemStack(Material.BEDROCK, 1),
-                    "vulnerability", "mode vulnerability");
+                "vulnerability", "mode vulnerability");
         }
 
         if (pe.getPlayer().hasPermission("asedit.togglesize")) {
             size = createIcon(new ItemStack(Material.PUFFERFISH, 1),
-                    "size", "mode size");
+                "size", "mode size");
         }
         if (pe.getPlayer().hasPermission("asedit.disableslots")) {
             disableSlots = createIcon(new ItemStack(Material.BARRIER), "disableslots", "mode disableslots");
@@ -166,63 +167,63 @@ public class Menu {
 
         if (pe.getPlayer().hasPermission("asedit.togglebaseplate")) {
             plate = createIcon(new ItemStack(Material.STONE_SLAB, 1),
-                    "baseplate", "mode baseplate");
+                "baseplate", "mode baseplate");
         }
 
         if (pe.getPlayer().hasPermission("asedit.movement")) {
             place = createIcon(new ItemStack(Material.MINECART, 1),
-                    "placement", "mode placement");
+                "placement", "mode placement");
         }
 
         if (pe.getPlayer().hasPermission("asedit.rotation")) {
             rotate = createIcon(new ItemStack(Material.COMPASS, 1),
-                    "rotate", "mode rotate");
+                "rotate", "mode rotate");
         }
 
         if (pe.getPlayer().hasPermission("asedit.equipment")) {
             equipment = createIcon(new ItemStack(Material.CHEST, 1),
-                    "equipment", "mode equipment");
+                "equipment", "mode equipment");
         }
 
         if (pe.getPlayer().hasPermission("asedit.copy")) {
             copy = createIcon(new ItemStack(Material.WRITABLE_BOOK),
-                    "copy", "mode copy");
+                "copy", "mode copy");
 
             slot1 = createIcon(new ItemStack(Material.DANDELION),
-                    "copyslot", "slot 1", "1");
+                "copyslot", "slot 1", "1");
 
             slot2 = createIcon(new ItemStack(Material.AZURE_BLUET, 2),
-                    "copyslot", "slot 2", "2");
+                "copyslot", "slot 2", "2");
 
             slot3 = createIcon(new ItemStack(Material.BLUE_ORCHID, 3),
-                    "copyslot", "slot 3", "3");
+                "copyslot", "slot 3", "3");
 
             slot4 = createIcon(new ItemStack(Material.PEONY, 4),
-                    "copyslot", "slot 4", "4");
+                "copyslot", "slot 4", "4");
         }
 
-        if (pe.getPlayer().hasPermission("asedit.paste")){
+        if (pe.getPlayer().hasPermission("asedit.paste")) {
             paste = createIcon(new ItemStack(Material.ENCHANTED_BOOK),
-                    "paste", "mode paste");
+                "paste", "mode paste");
         }
 
-        if(pe.getPlayer().hasPermission("asedit.head") && pe.plugin.getAllowedToRetrievePlayerHead()){
+        if (pe.getPlayer().hasPermission("asedit.head") && pe.plugin.getAllowedToRetrievePlayerHead()) {
             playerHead = createIcon(new ItemStack(Material.PLAYER_HEAD, 1),
-                    "playerheadmenu",
-                    "playerhead");
+                "playerheadmenu",
+                "playerhead");
         }
 
         help = createIcon(new ItemStack(Material.NETHER_STAR), "helpgui", "help");
 
         ItemStack[] items =
-                {
-                        xAxis, yAxis, zAxis, null, coarseAdj, fineAdj, null, rotate, place,
-                        null, headPos, playerHead, null, null, null, null, null, null,
-                        rightArmPos, bodyPos, leftArmPos, reset, null, null, showArms, visibility, size,
-                        rightLegPos, equipment, leftLegPos, null, null, toggleVulnerabilty, disableSlots, gravity, plate,
-                        null, copy, paste, null, null, null, null, itemFrameVisible, null,
-                        slot1, slot2, slot3, slot4, null, null, null, null, help
-                };
+            {
+                xAxis, yAxis, zAxis, null, coarseAdj, fineAdj, null, rotate, place,
+                null, headPos, playerHead, null, null, null, null, null, null,
+                rightArmPos, bodyPos, leftArmPos, reset, null, null, showArms, visibility, size,
+                rightLegPos, equipment, leftLegPos, null, null, toggleVulnerabilty, disableSlots, gravity, plate,
+                null, copy, paste, null, null, null, null, itemFrameVisible, null,
+                slot1, slot2, slot3, slot4, null, null, null, null, help
+            };
         menuInv.setContents(items);
     }
 

--- a/src/main/java/io/github/rypofalem/armorstandeditor/modes/AdjustmentMode.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/modes/AdjustmentMode.java
@@ -24,11 +24,11 @@ public enum AdjustmentMode {
 
     private String name;
 
-    AdjustmentMode(String name){
+    AdjustmentMode(String name) {
         this.name = name;
     }
 
-    public String toString(){
+    public String toString() {
         return name;
     }
 }

--- a/src/main/java/io/github/rypofalem/armorstandeditor/modes/ArmorStandData.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/modes/ArmorStandData.java
@@ -28,7 +28,7 @@ public class ArmorStandData {
     public boolean visible, size, basePlate, gravity, showArms;
     public ItemStack head, body, legs, feetsies, rightHand, leftHand;
 
-    ArmorStandData(ArmorStand as){
+    ArmorStandData(ArmorStand as) {
         this.headPos = as.getHeadPose();
         this.leftArmPos = as.getLeftArmPose();
         this.rightArmPos = as.getRightArmPose();

--- a/src/main/java/io/github/rypofalem/armorstandeditor/modes/Axis.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/modes/Axis.java
@@ -24,11 +24,11 @@ public enum Axis {
 
     String name;
 
-    Axis(String name){
+    Axis(String name) {
         this.name = name;
     }
 
-    public String toString(){
+    public String toString() {
         return name;
     }
 }

--- a/src/main/java/io/github/rypofalem/armorstandeditor/modes/CopySlots.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/modes/CopySlots.java
@@ -23,24 +23,24 @@ import org.bukkit.entity.ArmorStand;
 
 public class CopySlots {
     ArmorStandData[] slots = new ArmorStandData[9];
-    public byte currentSlot =0;
+    public byte currentSlot = 0;
 
     //returns true if parameters are acceptable, false otherwise.
-    public boolean changeSlots(byte slot){
-        if(slot < slots.length && slot>=0){
+    public boolean changeSlots(byte slot) {
+        if (slot < slots.length && slot >= 0) {
             currentSlot = slot;
             return true;
-        }else{
+        } else {
             return false;
         }
     }
 
-    public void copyDataToSlot(ArmorStand armorStand){
+    public void copyDataToSlot(ArmorStand armorStand) {
         slots[currentSlot] = new ArmorStandData(armorStand);
     }
 
     //returns null if there is not data in current slot
-    public ArmorStandData getDataToPaste(){
+    public ArmorStandData getDataToPaste() {
         return slots[currentSlot];
     }
 }

--- a/src/main/java/io/github/rypofalem/armorstandeditor/modes/EditMode.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/modes/EditMode.java
@@ -23,7 +23,7 @@ public enum EditMode {
     NONE("None"), INVISIBLE("Invisible"), SHOWARMS("ShowArms"), GRAVITY("Gravity"), BASEPLATE("BasePlate"), SIZE("Size"), COPY("Copy"), PASTE("Paste"),
     HEAD("Head"), BODY("Body"), LEFTARM("LeftArm"), RIGHTARM("RightArm"), LEFTLEG("LeftLeg"), RIGHTLEG("RightLeg"),
     PLACEMENT("Placement"), DISABLESLOTS("DisableSlots"), ROTATE("Rotate"), EQUIPMENT("Equipment"), RESET("Reset"), ITEMFRAME("ItemFrame"), ITEMFRAMEGLOW("ItemFrameGlow"),
-    VULNERABILITY("Vulnerability"), PLAYERHEAD("playerheadmenu");
+    VULNERABILITY("Vulnerability"), PLAYERHEAD("playerheadmenu"), GLOWING("armorstandglow");
 
     private String name;
 

--- a/src/main/java/io/github/rypofalem/armorstandeditor/modes/EditMode.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/modes/EditMode.java
@@ -27,11 +27,11 @@ public enum EditMode {
 
     private String name;
 
-    EditMode(String name){
+    EditMode(String name) {
         this.name = name;
     }
 
-    public String toString(){
+    public String toString() {
         return name;
     }
 }

--- a/src/main/java/io/github/rypofalem/armorstandeditor/protections/BentoBoxProtection.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/protections/BentoBoxProtection.java
@@ -19,6 +19,9 @@
 
 package io.github.rypofalem.armorstandeditor.protections;
 
+import org.bukkit.Bukkit;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
@@ -26,13 +29,9 @@ import world.bentobox.bentobox.lists.Flags;
 import world.bentobox.bentobox.managers.AddonsManager;
 import world.bentobox.bentobox.managers.IslandsManager;
 
-import org.bukkit.Bukkit;
-import org.bukkit.block.Block;
-import org.bukkit.entity.Player;
-
 import java.util.Optional;
 
-public class BentoBoxProtection implements Protection {
+public class BentoBoxProtection implements Protection  {
 
     private final boolean bentoEnabled;
 
@@ -43,29 +42,29 @@ public class BentoBoxProtection implements Protection {
 
     @Override
     public boolean checkPermission(Block block, Player player) {
-        if (!bentoEnabled || player.isOp() ||
-            player.hasPermission("asedit.ignoreProtection.bentobox") ||
-            player.hasPermission("bentobox.admin")) return true;
+        if(!bentoEnabled || player.isOp() ||
+                player.hasPermission("asedit.ignoreProtection.bentobox") ||
+                player.hasPermission("bentobox.admin")) return true;
 
         //Get the Bento Instance
         BentoBox myBento = BentoBox.getInstance();
-        if (myBento == null) return true;
+        if( myBento == null ) return true;
 
         //Get the Various Managers for Bentobox
         IslandsManager islandsManager = myBento.getIslandsManager();
         AddonsManager addonsManager = myBento.getAddonsManager();
 
         //Check first if BSkyblock is enabled or if the Player is Owner of that Island
-        if (addonsManager.getAddonByName("BSkyblock").isEmpty()) return true;
+        if(addonsManager.getAddonByName("BSkyblock").isEmpty()) return true;
 
         //Get the Location of the ArmorStand
         Optional<Island> islandOptional = islandsManager.getIslandAt(block.getLocation());
 
         //If there are no Islands Present
-        if (islandOptional.isEmpty()) return true;
+        if(islandOptional.isEmpty()) return true;
 
         //Do not run this check if the player is the owner of the island
-        if (islandsManager.isOwner(player.getWorld(), player.getUniqueId())) return true;
+        if(islandsManager.isOwner(player.getWorld(), player.getUniqueId())) return true;
 
         //Get the Island from the Island Optional
         Island theIsland = islandOptional.get();

--- a/src/main/java/io/github/rypofalem/armorstandeditor/protections/BentoBoxProtection.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/protections/BentoBoxProtection.java
@@ -19,9 +19,6 @@
 
 package io.github.rypofalem.armorstandeditor.protections;
 
-import org.bukkit.Bukkit;
-import org.bukkit.block.Block;
-import org.bukkit.entity.Player;
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
@@ -29,9 +26,13 @@ import world.bentobox.bentobox.lists.Flags;
 import world.bentobox.bentobox.managers.AddonsManager;
 import world.bentobox.bentobox.managers.IslandsManager;
 
+import org.bukkit.Bukkit;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+
 import java.util.Optional;
 
-public class BentoBoxProtection implements Protection  {
+public class BentoBoxProtection implements Protection {
 
     private final boolean bentoEnabled;
 
@@ -42,29 +43,29 @@ public class BentoBoxProtection implements Protection  {
 
     @Override
     public boolean checkPermission(Block block, Player player) {
-        if(!bentoEnabled || player.isOp() ||
-                player.hasPermission("asedit.ignoreProtection.bentobox") ||
-                player.hasPermission("bentobox.admin")) return true;
+        if (!bentoEnabled || player.isOp() ||
+            player.hasPermission("asedit.ignoreProtection.bentobox") ||
+            player.hasPermission("bentobox.admin")) return true;
 
         //Get the Bento Instance
         BentoBox myBento = BentoBox.getInstance();
-        if( myBento == null ) return true;
+        if (myBento == null) return true;
 
         //Get the Various Managers for Bentobox
         IslandsManager islandsManager = myBento.getIslandsManager();
         AddonsManager addonsManager = myBento.getAddonsManager();
 
         //Check first if BSkyblock is enabled or if the Player is Owner of that Island
-        if(addonsManager.getAddonByName("BSkyblock").isEmpty()) return true;
+        if (addonsManager.getAddonByName("BSkyblock").isEmpty()) return true;
 
         //Get the Location of the ArmorStand
         Optional<Island> islandOptional = islandsManager.getIslandAt(block.getLocation());
 
         //If there are no Islands Present
-        if(islandOptional.isEmpty()) return true;
+        if (islandOptional.isEmpty()) return true;
 
         //Do not run this check if the player is the owner of the island
-        if(islandsManager.isOwner(player.getWorld(), player.getUniqueId())) return true;
+        if (islandsManager.isOwner(player.getWorld(), player.getUniqueId())) return true;
 
         //Get the Island from the Island Optional
         Island theIsland = islandOptional.get();

--- a/src/main/java/io/github/rypofalem/armorstandeditor/protections/BentoBoxProtection.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/protections/BentoBoxProtection.java
@@ -55,13 +55,13 @@ public class BentoBoxProtection implements Protection  {
         AddonsManager addonsManager = myBento.getAddonsManager();
 
         //Check first if BSkyblock is enabled or if the Player is Owner of that Island
-        if(!addonsManager.getAddonByName("BSkyblock").isPresent()) return true;
+        if(addonsManager.getAddonByName("BSkyblock").isEmpty()) return true;
 
         //Get the Location of the ArmorStand
         Optional<Island> islandOptional = islandsManager.getIslandAt(block.getLocation());
 
         //If there are no Islands Present
-        if(!islandOptional.isPresent()) return true;
+        if(islandOptional.isEmpty()) return true;
 
         //Do not run this check if the player is the owner of the island
         if(islandsManager.isOwner(player.getWorld(), player.getUniqueId())) return true;

--- a/src/main/java/io/github/rypofalem/armorstandeditor/protections/GriefDefenderProtection.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/protections/GriefDefenderProtection.java
@@ -30,7 +30,7 @@ import org.bukkit.entity.Player;
 import static com.griefdefender.api.claim.TrustTypes.BUILDER;
 
 
-public class GriefDefenderProtection implements Protection  {
+public class GriefDefenderProtection implements Protection {
 
     private final boolean gdEnabled;
 

--- a/src/main/java/io/github/rypofalem/armorstandeditor/protections/GriefPreventionProtection.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/protections/GriefPreventionProtection.java
@@ -21,6 +21,7 @@ package io.github.rypofalem.armorstandeditor.protections;
 
 import me.ryanhamshire.GriefPrevention.Claim;
 import me.ryanhamshire.GriefPrevention.GriefPrevention;
+
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -31,37 +32,37 @@ import org.bukkit.entity.Player;
 /** @Deprecated
  * Plugin has gone unsupported for a while - Might be cleaned up later. **/
 
-public class GriefPreventionProtection implements Protection  {
+public class GriefPreventionProtection implements Protection {
 
     private boolean gpEnabled;
     private GriefPrevention griefPrevention = null;
 
     /** @Deprecated **/
-    public GriefPreventionProtection(){
+    public GriefPreventionProtection() {
         gpEnabled = Bukkit.getPluginManager().isPluginEnabled("GriefPrevention");
 
-        if(!gpEnabled) return;
+        if (!gpEnabled) return;
         griefPrevention = (GriefPrevention) Bukkit.getPluginManager().getPlugin("GriefPrevention");
     }
 
     /** @Deprecated **/
-    public boolean checkPermission(Block block, Player player){
-        if(!gpEnabled) return true;
-        if(player.hasPermission("asedit.ignoreProtection.griefPrevention")) return true;
+    public boolean checkPermission(Block block, Player player) {
+        if (!gpEnabled) return true;
+        if (player.hasPermission("asedit.ignoreProtection.griefPrevention")) return true;
 
         Location blockLoc = block.getLocation();
 
-        if(GriefPrevention.instance.claimsEnabledForWorld(blockLoc.getWorld())){
+        if (GriefPrevention.instance.claimsEnabledForWorld(blockLoc.getWorld())) {
 
             Claim landClaim = griefPrevention.dataStore.getClaimAt(blockLoc, false, null);
             Material blockMat = block.getType();
 
-            if(landClaim != null && landClaim.allowEdit(player) != null && landClaim.allowBuild(player,blockMat) != null){
+            if (landClaim != null && landClaim.allowEdit(player) != null && landClaim.allowBuild(player, blockMat) != null) {
                 player.sendMessage(ChatColor.RED + landClaim.allowEdit(player));
                 player.sendMessage(ChatColor.RED + landClaim.allowBuild(player, blockMat));
                 return false;
             }
-        } else{
+        } else {
             return true;
         }
 

--- a/src/main/java/io/github/rypofalem/armorstandeditor/protections/LandsProtection.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/protections/LandsProtection.java
@@ -72,7 +72,8 @@ public class LandsProtection implements Protection {
                     if (landAreaOfAS.getRole(playerUUID) == visitorRole) return false;
 
                     // If Player is Trusted OR Player is Owner of the Area/Claim, Allow Edits
-                    if (landAreaOfAS.isTrusted(playerUUID) || landAreaOfAS.getOwnerUID() == landPlayer.getUID()) return true; else if (landAreaOfAS.hasRoleFlag(playerUUID, BLOCK_BREAK) ||
+                    if (landAreaOfAS.isTrusted(playerUUID) || landAreaOfAS.getOwnerUID() == landPlayer.getUID()) return true;
+                    else if (landAreaOfAS.hasRoleFlag(playerUUID, BLOCK_BREAK) ||
                         landAreaOfAS.hasRoleFlag(playerUUID, BLOCK_PLACE) ||
                         landAreaOfAS.hasRoleFlag(playerUUID, INTERACT_CONTAINER) ||
                         landAreaOfAS.hasRoleFlag(playerUUID, INTERACT_GENERAL)) {

--- a/src/main/java/io/github/rypofalem/armorstandeditor/protections/LandsProtection.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/protections/LandsProtection.java
@@ -18,12 +18,14 @@
  */
 package io.github.rypofalem.armorstandeditor.protections;
 
-import io.github.rypofalem.armorstandeditor.ArmorStandEditorPlugin;
 import me.angeschossen.lands.api.LandsIntegration;
 import me.angeschossen.lands.api.land.Area;
 import me.angeschossen.lands.api.land.LandWorld;
 import me.angeschossen.lands.api.player.LandPlayer;
 import me.angeschossen.lands.api.role.Role;
+
+import io.github.rypofalem.armorstandeditor.ArmorStandEditorPlugin;
+
 import org.bukkit.Bukkit;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
@@ -54,44 +56,36 @@ public class LandsProtection implements Protection {
         //Get the world the play is in
         LandWorld landWorld = landsAPI.getWorld(player.getWorld());
 
-        if(landWorld != null) {
+        if (landWorld != null) {
 
             //Prep to do check for ClaimedArea
             Area landAreaOfAS = landsAPI.getArea(block.getLocation());
             Area landAreaOfPlayer = landsAPI.getArea(player.getLocation());
 
             if (landAreaOfAS != null) { //Block is in a Claimed Area
-                if(landAreaOfPlayer == landAreaOfAS) {
+                if (landAreaOfPlayer == landAreaOfAS) {
 
                     //Get Visitor Role for the Area of the AS
                     Role visitorRole = landAreaOfAS.getVisitorRole();
 
                     //If Player is a Visitor - Dont allow Edits
-                    if(landAreaOfAS.getRole(playerUUID) == visitorRole) return false;
+                    if (landAreaOfAS.getRole(playerUUID) == visitorRole) return false;
 
                     // If Player is Trusted OR Player is Owner of the Area/Claim, Allow Edits
-                    if (landAreaOfAS.isTrusted(playerUUID) || landAreaOfAS.getOwnerUID() == landPlayer.getUID())return true;
-
-                    // If in the Claim a Player can:
-                        // break Blocks,
-                        // Place
-                        // Interact with in Claimed Area
-                        // add items to a container
-                    // Allow Edits
-                    else if (landAreaOfAS.hasRoleFlag(playerUUID, BLOCK_BREAK) ||
-                            landAreaOfAS.hasRoleFlag(playerUUID, BLOCK_PLACE) ||
-                            landAreaOfAS.hasRoleFlag(playerUUID, INTERACT_CONTAINER) ||
-                            landAreaOfAS.hasRoleFlag(playerUUID, INTERACT_GENERAL)) {
+                    if (landAreaOfAS.isTrusted(playerUUID) || landAreaOfAS.getOwnerUID() == landPlayer.getUID()) return true; else if (landAreaOfAS.hasRoleFlag(playerUUID, BLOCK_BREAK) ||
+                        landAreaOfAS.hasRoleFlag(playerUUID, BLOCK_PLACE) ||
+                        landAreaOfAS.hasRoleFlag(playerUUID, INTERACT_CONTAINER) ||
+                        landAreaOfAS.hasRoleFlag(playerUUID, INTERACT_GENERAL)) {
 
                         return true;
-                    } else{ // Any other case, dont allow edits
+                    } else { // Any other case, dont allow edits
                         return false;
                     }
                 } else return false; //If the land areas are different
             } else { //If the AS is in the Wilderness
                 return true;
             }
-        }else { //if the ArmorStand is in a world
+        } else { //if the ArmorStand is in a world
             return true;
         }
     }

--- a/src/main/java/io/github/rypofalem/armorstandeditor/protections/PlotSquaredProtection.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/protections/PlotSquaredProtection.java
@@ -56,13 +56,14 @@ public class PlotSquaredProtection implements Protection {
 
         //Get the Area of the PLot
         PlotArea area = plotLocation.getPlotArea();
-        if(area == null){ //If the Area is not a Plot, then we assume its a road, we return if a player can build on roads or not
-            return player.hasPermission("plots.admin.build.road");
-        }
+
+        //If the Area is not a Plot, then we assume its a road, we return if a player can build on roads or not
+        if(area == null) return player.hasPermission("plots.admin.build.road");
 
         //Get the Plot
         Plot plot = area.getPlot(plotLocation);
-        //If Plot is
+
+        //Rerun the Area check
         if(plot == null) return player.hasPermission("plots.admin.build.road");
 
         //Get the Player

--- a/src/main/java/io/github/rypofalem/armorstandeditor/protections/PlotSquaredProtection.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/protections/PlotSquaredProtection.java
@@ -19,24 +19,31 @@
 package io.github.rypofalem.armorstandeditor.protections;
 
 import com.plotsquared.bukkit.BukkitPlatform;
+import com.plotsquared.core.PlotAPI;
 import com.plotsquared.core.location.Location;
+import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.plot.Plot;
 import com.plotsquared.core.plot.PlotArea;
 
+import com.sk89q.worldedit.math.BlockVector3;
 import org.bukkit.Bukkit;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 
+import java.util.UUID;
+
 public class PlotSquaredProtection implements Protection {
 
     private final boolean psEnabled;
-    private BukkitPlatform psPlatform = null;
+    private PlotAPI plotAPI = null;
 
     public PlotSquaredProtection() {
         psEnabled = Bukkit.getPluginManager().isPluginEnabled("PlotSquared");
 
         if (!psEnabled) return;
-        psPlatform = (BukkitPlatform) Bukkit.getPluginManager().getPlugin("PlotSquared");
+        if(plotAPI == null) return;
+        plotAPI = new PlotAPI();
+
     }
 
     public boolean checkPermission(Block block, Player player) {
@@ -44,14 +51,29 @@ public class PlotSquaredProtection implements Protection {
         if (player.isOp()) return true;
         if (player.hasPermission("asedit.ignoreProtection.plotSquared")) return true;
 
-        Location location = Location.at(block.getWorld().getName(),
-            block.getLocation().getBlockX(),
-            block.getLocation().getBlockY(),
-            block.getLocation().getBlockZ());
+        //Get the Location of the Plot
+        Location plotLocation = Location.at(player.getWorld().getName(), BlockVector3.at(block.getX(), block.getY(), block.getZ()));
 
-        PlotArea area = psPlatform.plotAreaManager().getPlotArea(location);
-        if (area == null) return true;
-        Plot plot = area.getPlot(location);
-        return plot == null || plot.isAdded(player.getUniqueId());
+        //Get the Area of the PLot
+        PlotArea area = plotLocation.getPlotArea();
+        if(area == null){ //If the Area is not a Plot, then we assume its a road, we return if a player can build on roads or not
+            return player.hasPermission("plots.admin.build.road");
+        }
+
+        //Get the Plot
+        Plot plot = area.getPlot(plotLocation);
+        //If Plot is
+        if(plot == null) return player.hasPermission("plots.admin.build.road");
+
+        //Get the Player
+        PlotPlayer<?> plotPlayer = plotAPI.wrapPlayer(player.getUniqueId());
+        if(plotPlayer == null) return true;
+
+        //Get the UUID of the PlotPlayer
+        UUID uuid = plotPlayer.getUUID();
+
+        //Return if they are added to the plot or if they are OP and have the Permission to build anywhere
+        return plot.isAdded(uuid) || plotPlayer.hasPermission("plots.admin.build.other");
+
     }
 }

--- a/src/main/java/io/github/rypofalem/armorstandeditor/protections/PlotSquaredProtection.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/protections/PlotSquaredProtection.java
@@ -19,38 +19,38 @@
 package io.github.rypofalem.armorstandeditor.protections;
 
 import com.plotsquared.bukkit.BukkitPlatform;
+import com.plotsquared.core.location.Location;
 import com.plotsquared.core.plot.Plot;
 import com.plotsquared.core.plot.PlotArea;
-import com.plotsquared.core.location.Location;
 
 import org.bukkit.Bukkit;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 
-public class PlotSquaredProtection implements Protection  {
+public class PlotSquaredProtection implements Protection {
 
     private final boolean psEnabled;
     private BukkitPlatform psPlatform = null;
 
-    public PlotSquaredProtection(){
+    public PlotSquaredProtection() {
         psEnabled = Bukkit.getPluginManager().isPluginEnabled("PlotSquared");
 
         if (!psEnabled) return;
         psPlatform = (BukkitPlatform) Bukkit.getPluginManager().getPlugin("PlotSquared");
     }
 
-    public boolean checkPermission(Block block, Player player){
-        if(!psEnabled) return true;
-        if(player.isOp()) return true;
-        if(player.hasPermission("asedit.ignoreProtection.plotSquared")) return true;
+    public boolean checkPermission(Block block, Player player) {
+        if (!psEnabled) return true;
+        if (player.isOp()) return true;
+        if (player.hasPermission("asedit.ignoreProtection.plotSquared")) return true;
 
         Location location = Location.at(block.getWorld().getName(),
-                block.getLocation().getBlockX(),
-                block.getLocation().getBlockY(),
-                block.getLocation().getBlockZ());
+            block.getLocation().getBlockX(),
+            block.getLocation().getBlockY(),
+            block.getLocation().getBlockZ());
 
         PlotArea area = psPlatform.plotAreaManager().getPlotArea(location);
-        if(area == null) return true;
+        if (area == null) return true;
         Plot plot = area.getPlot(location);
         return plot == null || plot.isAdded(player.getUniqueId());
     }

--- a/src/main/java/io/github/rypofalem/armorstandeditor/protections/PlotSquaredProtection.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/protections/PlotSquaredProtection.java
@@ -75,7 +75,7 @@ public class PlotSquaredProtection implements Protection {
         UUID uuid = plotPlayer.getUUID();
 
         //Return if they are added to the plot or if they are OP and have the Permission to build anywhere
-        return plot.isAdded(uuid) || plotPlayer.hasPermission("plots.admin.build.other") || plotPlayer.hasPermission("plots.admin.build.other");
+        return plot.isAdded(uuid) || plotPlayer.hasPermission("plots.admin.build.other");
 
     }
 }

--- a/src/main/java/io/github/rypofalem/armorstandeditor/protections/PlotSquaredProtection.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/protections/PlotSquaredProtection.java
@@ -56,13 +56,15 @@ public class PlotSquaredProtection implements Protection {
         PlotArea area = plotLocation.getPlotArea();
 
         //If the Area is not a Plot, then we assume its a road, we return if a player can build on roads or not
-        if(area == null) return player.hasPermission("plots.admin.build.road");
+        if(area == null)
+            return player.hasPermission("plots.admin.build.road");
 
         //Get the Plot
         Plot plot = area.getPlot(plotLocation);
 
         //Rerun the Area check
-        if(plot == null) return player.hasPermission("plots.admin.build.road");
+        if(plot == null)
+            return player.hasPermission("plots.admin.build.road");
 
         //Get the Player
         PlotPlayer<?> plotPlayer = plotAPI.wrapPlayer(player.getUniqueId());
@@ -73,7 +75,7 @@ public class PlotSquaredProtection implements Protection {
         UUID uuid = plotPlayer.getUUID();
 
         //Return if they are added to the plot or if they are OP and have the Permission to build anywhere
-        return plot.isAdded(uuid) || plotPlayer.hasPermission("plots.admin.build.other");
+        return plot.isAdded(uuid) || plotPlayer.hasPermission("plots.admin.build.other") || plotPlayer.hasPermission("plots.admin.build.other");
 
     }
 }

--- a/src/main/java/io/github/rypofalem/armorstandeditor/protections/PlotSquaredProtection.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/protections/PlotSquaredProtection.java
@@ -35,21 +35,19 @@ import java.util.UUID;
 public class PlotSquaredProtection implements Protection {
 
     private final boolean psEnabled;
-    private PlotAPI plotAPI = null;
+    private PlotAPI plotAPI;
 
     public PlotSquaredProtection() {
         psEnabled = Bukkit.getPluginManager().isPluginEnabled("PlotSquared");
 
         if (!psEnabled) return;
-        if(plotAPI == null) return;
-        plotAPI = new PlotAPI();
-
     }
 
     public boolean checkPermission(Block block, Player player) {
         if (!psEnabled) return true;
         if (player.isOp()) return true;
         if (player.hasPermission("asedit.ignoreProtection.plotSquared")) return true;
+        if (plotAPI == null) plotAPI = new PlotAPI();
 
         //Get the Location of the Plot
         Location plotLocation = Location.at(player.getWorld().getName(), BlockVector3.at(block.getX(), block.getY(), block.getZ()));
@@ -68,6 +66,7 @@ public class PlotSquaredProtection implements Protection {
 
         //Get the Player
         PlotPlayer<?> plotPlayer = plotAPI.wrapPlayer(player.getUniqueId());
+
         if(plotPlayer == null) return true;
 
         //Get the UUID of the PlotPlayer

--- a/src/main/java/io/github/rypofalem/armorstandeditor/protections/SkyblockProtection.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/protections/SkyblockProtection.java
@@ -21,19 +21,20 @@ package io.github.rypofalem.armorstandeditor.protections;
 import com.bgsoftware.superiorskyblock.api.SuperiorSkyblockAPI;
 import com.bgsoftware.superiorskyblock.api.island.Island;
 import com.bgsoftware.superiorskyblock.api.wrappers.SuperiorPlayer;
+
 import org.bukkit.Bukkit;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 
-public class SkyblockProtection implements Protection  {
+public class SkyblockProtection implements Protection {
     private final boolean skyblockEnabled;
 
-    public SkyblockProtection(){
+    public SkyblockProtection() {
         //NOTE FROM AUTHOR: I know there are many plugins that have Skyblock. I am using SuperiorSkyBlock2 as an Example!
         //IF YOU WANT YOUR SKYBLOCK ADDED, PLEASE SUBMIT A FEATURE REQUEST!
 
         skyblockEnabled = Bukkit.getPluginManager().isPluginEnabled("SuperiorSkyblock2");
-        if(!skyblockEnabled) return;
+        if (!skyblockEnabled) return;
     }
 
     public boolean checkPermission(Block block, Player player) {

--- a/src/main/java/io/github/rypofalem/armorstandeditor/protections/TownyProtection.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/protections/TownyProtection.java
@@ -28,18 +28,18 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 
 //FIX for https://github.com/Wolfieheart/ArmorStandEditor-Issues/issues/15
-public class TownyProtection implements Protection  {
+public class TownyProtection implements Protection {
     private final boolean tEnabled;
 
 
-    public TownyProtection(){
+    public TownyProtection() {
         tEnabled = Bukkit.getPluginManager().isPluginEnabled("Towny");
     }
 
-    public boolean checkPermission(Block block, Player player){
-        if(!tEnabled) return true;
-        if(player.isOp()) return true;
-        if(player.hasPermission("asedit.ignoreProtection.towny")) return true; //Add Additional Permission
+    public boolean checkPermission(Block block, Player player) {
+        if (!tEnabled) return true;
+        if (player.isOp()) return true;
+        if (player.hasPermission("asedit.ignoreProtection.towny")) return true; //Add Additional Permission
 
         Location playerLoc = player.getLocation();
 

--- a/src/main/java/io/github/rypofalem/armorstandeditor/protections/WorldGuardProtection.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/protections/WorldGuardProtection.java
@@ -27,7 +27,6 @@ import com.sk89q.worldguard.protection.flags.Flags;
 import com.sk89q.worldguard.protection.regions.RegionContainer;
 import com.sk89q.worldguard.protection.regions.RegionQuery;
 
-
 import org.bukkit.Bukkit;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
@@ -36,17 +35,17 @@ public class WorldGuardProtection implements Protection {
     private final boolean wgEnabled;
     private RegionQuery regionQry;
 
-    public WorldGuardProtection(){
+    public WorldGuardProtection() {
         wgEnabled = Bukkit.getPluginManager().isPluginEnabled("WorldGuard");
-        if(!wgEnabled) return;
+        if (!wgEnabled) return;
 
         RegionContainer regionContainer = WorldGuard.getInstance().getPlatform().getRegionContainer();
         regionQry = regionContainer.createQuery();
     }
 
-    public boolean checkPermission(Block block, Player player){
+    public boolean checkPermission(Block block, Player player) {
         if (!wgEnabled) return true;
-        if(player.isOp()) return true;
+        if (player.isOp()) return true;
         if (player.hasPermission("asedit.ignoreProtection.worldGuard")) return true;
 
         LocalPlayer localPlayer = WorldGuardPlugin.inst().wrapPlayer(player);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -3,7 +3,7 @@
 #-----------------------------#
 
 #DO NOT CHANGE THIS - CHANGES AUTOMATICALLY PER UPDATE
-version: "1.20.2-44"
+version: "1.20.x-44"
 
 #----------- LANGUAGE
 #Name of the language file you wish to use

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -13,14 +13,22 @@ version: "1.20.1-44"
 lang: en_US.yml
 
 #----------- UPDATE NOTIFICATIONS
-#Enable or Disable the Update Checker
+# Enable or Disable the Update Checker
 runTheUpdateChecker: true
 
 # When runTheUpdateChecker is true, we will also check every X hours
 check-interval: 24
 
-#Set this to allow your operators to get messages in game w.r.t Plugin updates
+# Set this to allow your operators to get messages in game w.r.t Plugin updates
 opUpdateNotification: false
+
+#----------- WORLD SETTINGS
+# Add in a list of Worlds where ArmorStandEditing is allowed to happen
+# Please add your own worlds to this list. All Default Worlds are supported.
+allowed-worlds:
+  - world
+  - world_nether
+  - world_the_end
 
 #----------- TOOL SETTINGS
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -3,7 +3,7 @@
 #-----------------------------#
 
 #DO NOT CHANGE THIS - CHANGES AUTOMATICALLY PER UPDATE
-version: "1.20.1-44"
+version: "1.20.2-44"
 
 #----------- LANGUAGE
 #Name of the language file you wish to use

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -3,7 +3,7 @@
 #-----------------------------#
 
 #DO NOT CHANGE THIS - CHANGES AUTOMATICALLY PER UPDATE
-version: "1.20.1-43.2"
+version: "1.20.1-44"
 
 #----------- LANGUAGE
 #Name of the language file you wish to use

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -3,7 +3,7 @@
 #-----------------------------#
 
 #DO NOT CHANGE THIS - CHANGES AUTOMATICALLY PER UPDATE
-version: "1.20.x-44"
+version: "1.20.2-44"
 
 #----------- LANGUAGE
 #Name of the language file you wish to use

--- a/src/main/resources/lang/de_DE.yml
+++ b/src/main/resources/lang/de_DE.yml
@@ -76,6 +76,10 @@ noplayerhead:
   msg: Please turn on the ability to retrieve player heads in the config file.
 playerheaderror:
   msg: Unable to Retrieve Player Head.
+notincorrectworld:
+  msg: Sorry but you are not in the correct world to use ArmorStandEditor.
+unabledestroycreative:
+  msg: Unable to Destroy this Invulnerable ArmorStand in Creative Mode.
 help:
   msg: "1. Halte das Bearbeitungswerkzeug(<x>) in deiner Haupthand.
 

--- a/src/main/resources/lang/de_DE.yml
+++ b/src/main/resources/lang/de_DE.yml
@@ -110,6 +110,20 @@ cantedit:
   msg: Entschuldigung, du kannst hier keine Rüstungsständer bearbeiten!
 noperm:
   msg: Du hast keine Erlaubnis diesen Befehl zu nutzen!
+nopermoption:
+  msg: You don't have permission to use the <x> Option!
+  basic: Normal ArmorStand
+  showarms: Show Arms
+  armorstandvisibility: Armor Stand Visibility
+  baseplate: Set Baseplate Visibility
+  gravity: Toggle Gravity
+  vulnerability: Toggle Vulnerability!
+  itemframevisibility: Item Frame Visibility
+  size: Toggle ArmorStand Size
+  disableslots: Toggle Equipment Lock
+  paste: Paste ArmorStand Config
+  copy: Copy ArmorStand Config
+  reset: Reset ArmorStand Config
 noslotnumcom:
   msg: Du musst eine Slotnummer angeben!
 noadjcom:
@@ -232,6 +246,10 @@ helpgui:
   msg: Hilfe!
   description:
     msg: Klicke hier um Hilfe zu erhalten!
+blankslot:
+  msg: Nothing here
+  description:
+    msg: Just a placeholder item. Clicking me will not do anything.
 
 #icons (equipment menu)
 disabled:

--- a/src/main/resources/lang/de_DE.yml
+++ b/src/main/resources/lang/de_DE.yml
@@ -80,6 +80,8 @@ notincorrectworld:
   msg: Sorry but you are not in the correct world to use ArmorStandEditor.
 unabledestroycreative:
   msg: Unable to Destroy this Invulnerable ArmorStand in Creative Mode.
+stats:
+  msg: Here are the statistics for your ArmorStand.
 help:
   msg: "1. Halte das Bearbeitungswerkzeug(<x>) in deiner Haupthand.
 
@@ -124,8 +126,12 @@ nopermoption:
   paste: Paste ArmorStand Config
   copy: Copy ArmorStand Config
   reset: Reset ArmorStand Config
+  stats: View ArmorStand Statistics
+  armorstandglow: Toggle ArmorStand Glow
 noslotnumcom:
   msg: Du musst eine Slotnummer angeben!
+norangestats:
+  msg: Please get next to an ArmorStand before running this command.
 noadjcom:
   msg: Du musst Grob oder Fein auswählen!
 noaxiscom:
@@ -246,10 +252,22 @@ helpgui:
   msg: Hilfe!
   description:
     msg: Klicke hier um Hilfe zu erhalten!
+itemframevisible:
+  msg: Itemframe Visibility
+  description:
+    msg: Toggles an itemframes visibility
+playerheadmenu:
+  msg: Player Head
+  description:
+    msg: Please use /ase playerhead <name>
 blankslot:
   msg: Nothing here
   description:
     msg: Just a placeholder item. Clicking me will not do anything.
+armorstandglow:
+  msg: Toggle ArmorStand Glow
+  description:
+    msg: Turn ArmorStand Glowing on or off.
 
 #icons (equipment menu)
 disabled:

--- a/src/main/resources/lang/en_US.yml
+++ b/src/main/resources/lang/en_US.yml
@@ -129,7 +129,7 @@ nopermoption:
   armorstandvisibility: Armor Stand Visibility
   baseplate: Set Baseplate Visibility
   gravity: Toggle Gravity
-  vulnerability: Toggle Vulnerability!
+  vulnerability: Toggle Vulnerability
   itemframevisibility: Item Frame Visibility
   size: Toggle ArmorStand Size
   disableslots: Toggle Equipment Lock
@@ -137,6 +137,7 @@ nopermoption:
   copy: Copy ArmorStand Config
   reset: Reset ArmorStand Config
   stats: View ArmorStand Statistics
+  armorstandglow: Toggle ArmorStand Glow
 norangestats:
   msg: Please get next to an ArmorStand before running this command.
 noslotnumcom:
@@ -277,6 +278,10 @@ blankslot:
   msg: Nothing here
   description:
     msg: Just a placeholder item. Clicking me will not do anything.
+armorstandglow:
+  msg: Toggle ArmorStand Glow
+  description:
+    msg: Turn ArmorStand Glowing on or off.
 
 #icons (equipment menu)
 disabled:

--- a/src/main/resources/lang/en_US.yml
+++ b/src/main/resources/lang/en_US.yml
@@ -88,6 +88,8 @@ playerheaderror:
   msg: Unable to Retrieve Player Head.
 unabledestroycreative:
   msg: Unable to Destroy this Invulnerable ArmorStand in Creative Mode.
+notincorrectworld:
+  msg: Sorry but you are not in the correct world to use ArmorStandEditor.
 playerheadhelp:
   msg: "Please use /ase playerhead <name> to get a players head. Ex of the command - /ase playerhead Wolfieheart_"
 help:

--- a/src/main/resources/lang/en_US.yml
+++ b/src/main/resources/lang/en_US.yml
@@ -90,6 +90,8 @@ unabledestroycreative:
   msg: Unable to Destroy this Invulnerable ArmorStand in Creative Mode.
 notincorrectworld:
   msg: Sorry but you are not in the correct world to use ArmorStandEditor.
+stats:
+  msg: Here are the statistics for your ArmorStand.
 playerheadhelp:
   msg: "Please use /ase playerhead <name> to get a players head. Ex of the command - /ase playerhead Wolfieheart_"
 help:
@@ -134,6 +136,9 @@ nopermoption:
   paste: Paste ArmorStand Config
   copy: Copy ArmorStand Config
   reset: Reset ArmorStand Config
+  stats: View ArmorStand Statistics
+norangestats:
+  msg: Please get next to an ArmorStand before running this command.
 noslotnumcom:
   msg: You must specify a slot number!
 noadjcom:

--- a/src/main/resources/lang/en_US.yml
+++ b/src/main/resources/lang/en_US.yml
@@ -120,6 +120,20 @@ cantedit:
   msg: Sorry, you cannot edit armor stands here!
 noperm:
   msg: You don't have permission to use this!
+nopermoption:
+  msg: You don't have permission to use the <x> Option!
+  basic: Normal ArmorStand
+  showarms: Show Arms
+  armorstandvisibility: Armor Stand Visibility
+  baseplate: Set Baseplate Visibility
+  gravity: Toggle Gravity
+  vulnerability: Toggle Vulnerability!
+  itemframevisibility: Item Frame Visibility
+  size: Toggle ArmorStand Size
+  disableslots: Toggle Equipment Lock
+  paste: Paste ArmorStand Config
+  copy: Copy ArmorStand Config
+  reset: Reset ArmorStand Config
 noslotnumcom:
   msg: You must specify a slot number!
 noadjcom:
@@ -254,6 +268,10 @@ playerheadmenu:
   msg: Player Head
   description:
     msg: Please use /ase playerhead <name>
+blankslot:
+  msg: Nothing here
+  description:
+    msg: Just a placeholder item. Clicking me will not do anything.
 
 #icons (equipment menu)
 disabled:

--- a/src/main/resources/lang/en_US.yml
+++ b/src/main/resources/lang/en_US.yml
@@ -86,6 +86,8 @@ noplayerhead:
   msg: Please turn on the ability to retrieve player heads in the config file and/or check your permissions to confirm that you have asedit.head set to true.
 playerheaderror:
   msg: Unable to Retrieve Player Head.
+unabledestroycreative:
+  msg: Unable to Destroy this Invulnerable ArmorStand in Creative Mode.
 playerheadhelp:
   msg: "Please use /ase playerhead <name> to get a players head. Ex of the command - /ase playerhead Wolfieheart_"
 help:

--- a/src/main/resources/lang/es_ES.yml
+++ b/src/main/resources/lang/es_ES.yml
@@ -73,6 +73,10 @@ noplayerhead:
   msg: Please turn on the ability to retrieve player heads in the config file.
 playerheaderror:
   msg: Unable to Retrieve Player Head.
+notincorrectworld:
+  msg: Sorry but you are not in the correct world to use ArmorStandEditor.
+unabledestroycreative:
+  msg: Unable to Destroy this Invulnerable ArmorStand in Creative Mode.
 help:
   msg: "1. Manten la herramienta de edición (<x>) en tu mano principal.
 

--- a/src/main/resources/lang/es_ES.yml
+++ b/src/main/resources/lang/es_ES.yml
@@ -105,8 +105,22 @@ give:
 #warn
 cantedit:
   msg: Lo siento, no puedes editar soportes aqui.
-noperm: 
+noperm:
   msg: No tienes permiso para usar esto
+nopermoption:
+  msg: You don't have permission to use the <x> Option!
+  basic: Normal ArmorStand
+  showarms: Show Arms
+  armorstandvisibility: Armor Stand Visibility
+  baseplate: Set Baseplate Visibility
+  gravity: Toggle Gravity
+  vulnerability: Toggle Vulnerability!
+  itemframevisibility: Item Frame Visibility
+  size: Toggle ArmorStand Size
+  disableslots: Toggle Equipment Lock
+  paste: Paste ArmorStand Config
+  copy: Copy ArmorStand Config
+  reset: Reset ArmorStand Config
 noslotnumcom: 
   msg: Tienes que especificar un número de soot
 noadjcom:
@@ -229,6 +243,10 @@ vulnerability:
   msg: Toggle Vulnerability
   description:
     msg: Toggles an item's vulnerability state
+blankslot:
+  msg: Nothing here
+  description:
+    msg: Just a placeholder item. Clicking me will not do anything.
 
 #icons (equipment menu)
 disabled: 

--- a/src/main/resources/lang/es_ES.yml
+++ b/src/main/resources/lang/es_ES.yml
@@ -101,12 +101,16 @@ helpdiscord:
   msg: "or join our Discord: https://discord.gg/3BbJKWpTCj"
 give:
   msg: Player given Item with CustomModelData
+stats:
+  msg: Here are the statistics for your ArmorStand.
 
 #warn
 cantedit:
   msg: Lo siento, no puedes editar soportes aqui.
 noperm:
   msg: No tienes permiso para usar esto
+norangestats:
+  msg: Please get next to an ArmorStand before running this command.
 nopermoption:
   msg: You don't have permission to use the <x> Option!
   basic: Normal ArmorStand
@@ -121,6 +125,8 @@ nopermoption:
   paste: Paste ArmorStand Config
   copy: Copy ArmorStand Config
   reset: Reset ArmorStand Config
+  stats: View ArmorStand Statistics
+  armorstandglow: Toggle ArmorStand Glow
 noslotnumcom: 
   msg: Tienes que especificar un número de soot
 noadjcom:
@@ -243,10 +249,22 @@ vulnerability:
   msg: Toggle Vulnerability
   description:
     msg: Toggles an item's vulnerability state
+itemframevisible:
+  msg: Itemframe Visibility
+  description:
+    msg: Toggles an itemframes visibility
+playerheadmenu:
+  msg: Player Head
+  description:
+    msg: Please use /ase playerhead <name>
 blankslot:
   msg: Nothing here
   description:
     msg: Just a placeholder item. Clicking me will not do anything.
+armorstandglow:
+  msg: Toggle ArmorStand Glow
+  description:
+    msg: Turn ArmorStand Glowing on or off.
 
 #icons (equipment menu)
 disabled: 

--- a/src/main/resources/lang/fr_FR.yml
+++ b/src/main/resources/lang/fr_FR.yml
@@ -75,6 +75,10 @@ notincorrectworld:
   msg: Sorry but you are not in the correct world to use ArmorStandEditor.
 unabledestroycreative:
   msg: Unable to Destroy this Invulnerable ArmorStand in Creative Mode.
+stats:
+  msg: Here are the statistics for your ArmorStand.
+playerheadhelp:
+  msg: "Please use /ase playerhead <name> to get a players head. Ex of the command - /ase playerhead Wolfieheart_"
 help:
   msg: "1. Tenez l'outil d'édition (<x>) dans votre main principale.
   
@@ -123,6 +127,10 @@ nopermoption:
   paste: Paste ArmorStand Config
   copy: Copy ArmorStand Config
   reset: Reset ArmorStand Config
+  stats: View ArmorStand Statistics
+  armorstandglow: Toggle ArmorStand Glow
+norangestats:
+  msg: Please get next to an ArmorStand before running this command.
 noslotnumcom: 
   msg: Vous devez spécifier un numéro d'emplacement de copie !
 noadjcom:
@@ -251,10 +259,18 @@ itemframevisible:
   msg: Visibilité (Item Frame)
   description:
     msg: Rend visible ou invisible un Item Frame
+playerheadmenu:
+  msg: Player Head
+  description:
+    msg: Please use /ase playerhead <name>
 blankslot:
   msg: Nothing here
   description:
     msg: Just a placeholder item. Clicking me will not do anything.
+armorstandglow:
+  msg: Toggle ArmorStand Glow
+  description:
+    msg: Turn ArmorStand Glowing on or off.
 
 #icons (equipment menu)
 disabled: 

--- a/src/main/resources/lang/fr_FR.yml
+++ b/src/main/resources/lang/fr_FR.yml
@@ -71,6 +71,10 @@ doubletarget:
   msg: Regardez un armor stand ou un item frame, pas les deux!
 nodoubletarget:
   msg: Regardez un armor stand ou un item frame avant de changer de main!
+notincorrectworld:
+  msg: Sorry but you are not in the correct world to use ArmorStandEditor.
+unabledestroycreative:
+  msg: Unable to Destroy this Invulnerable ArmorStand in Creative Mode.
 help:
   msg: "1. Tenez l'outil d'édition (<x>) dans votre main principale.
   

--- a/src/main/resources/lang/fr_FR.yml
+++ b/src/main/resources/lang/fr_FR.yml
@@ -107,8 +107,22 @@ playerheaderror:
 #warn
 cantedit:
   msg: Désolé, vous ne pouvez pas modifier des armor stands ici !
-noperm: 
+noperm:
   msg: Vous n'avez pas la permission d'utiliser ceci !
+nopermoption:
+  msg: You don't have permission to use the <x> Option!
+  basic: Normal ArmorStand
+  showarms: Show Arms
+  armorstandvisibility: Armor Stand Visibility
+  baseplate: Set Baseplate Visibility
+  gravity: Toggle Gravity
+  vulnerability: Toggle Vulnerability!
+  itemframevisibility: Item Frame Visibility
+  size: Toggle ArmorStand Size
+  disableslots: Toggle Equipment Lock
+  paste: Paste ArmorStand Config
+  copy: Copy ArmorStand Config
+  reset: Reset ArmorStand Config
 noslotnumcom: 
   msg: Vous devez spécifier un numéro d'emplacement de copie !
 noadjcom:
@@ -237,6 +251,10 @@ itemframevisible:
   msg: Visibilité (Item Frame)
   description:
     msg: Rend visible ou invisible un Item Frame
+blankslot:
+  msg: Nothing here
+  description:
+    msg: Just a placeholder item. Clicking me will not do anything.
 
 #icons (equipment menu)
 disabled: 

--- a/src/main/resources/lang/ja_JP.yml
+++ b/src/main/resources/lang/ja_JP.yml
@@ -76,6 +76,10 @@ noplayerhead:
   msg: Please turn on the ability to retrieve player heads in the config file.
 playerheaderror:
   msg: Unable to Retrieve Player Head.
+notincorrectworld:
+  msg: Sorry but you are not in the correct world to use ArmorStandEditor.
+unabledestroycreative:
+  msg: Unable to Destroy this Invulnerable ArmorStand in Creative Mode.
 help:
   msg: "1. 編集ツール(<x>)を手に持ちます。
 

--- a/src/main/resources/lang/ja_JP.yml
+++ b/src/main/resources/lang/ja_JP.yml
@@ -76,10 +76,14 @@ noplayerhead:
   msg: Please turn on the ability to retrieve player heads in the config file.
 playerheaderror:
   msg: Unable to Retrieve Player Head.
-notincorrectworld:
-  msg: Sorry but you are not in the correct world to use ArmorStandEditor.
 unabledestroycreative:
   msg: Unable to Destroy this Invulnerable ArmorStand in Creative Mode.
+notincorrectworld:
+  msg: Sorry but you are not in the correct world to use ArmorStandEditor.
+stats:
+  msg: Here are the statistics for your ArmorStand.
+playerheadhelp:
+  msg: "Please use /ase playerhead <name> to get a players head. Ex of the command - /ase playerhead Wolfieheart_"
 help:
   msg: "1. 編集ツール(<x>)を手に持ちます。
 
@@ -122,6 +126,10 @@ nopermoption:
   paste: Paste ArmorStand Config
   copy: Copy ArmorStand Config
   reset: Reset ArmorStand Config
+  stats: View ArmorStand Statistics
+  armorstandglow: Toggle ArmorStand Glow
+norangestats:
+  msg: Please get next to an ArmorStand before running this command.
 noslotnumcom:
   msg: スロット番号を指定する必要があります！
 noadjcom:
@@ -241,14 +249,22 @@ helpgui:
   msg: ヘルプ
   description:
     msg: ここをクリックするとヘルプが確認できます！
-vulnerability:
-  msg: Toggle Vulnerability
+itemframevisible:
+  msg: Itemframe Visibility
   description:
-    msg: Toggles an item's vulnerability state
+    msg: Toggles an itemframes visibility
+playerheadmenu:
+  msg: Player Head
+  description:
+    msg: Please use /ase playerhead <name>
 blankslot:
   msg: Nothing here
   description:
     msg: Just a placeholder item. Clicking me will not do anything.
+armorstandglow:
+  msg: Toggle ArmorStand Glow
+  description:
+    msg: Turn ArmorStand Glowing on or off.
 
 #icons (equipment menu)
 disabled:

--- a/src/main/resources/lang/ja_JP.yml
+++ b/src/main/resources/lang/ja_JP.yml
@@ -108,6 +108,20 @@ cantedit:
   msg: 申し訳ありません、ここでアーマースタンドを編集することができません！
 noperm:
   msg: 使用する権限がありません！
+nopermoption:
+  msg: You don't have permission to use the <x> Option!
+  basic: Normal ArmorStand
+  showarms: Show Arms
+  armorstandvisibility: Armor Stand Visibility
+  baseplate: Set Baseplate Visibility
+  gravity: Toggle Gravity
+  vulnerability: Toggle Vulnerability!
+  itemframevisibility: Item Frame Visibility
+  size: Toggle ArmorStand Size
+  disableslots: Toggle Equipment Lock
+  paste: Paste ArmorStand Config
+  copy: Copy ArmorStand Config
+  reset: Reset ArmorStand Config
 noslotnumcom:
   msg: スロット番号を指定する必要があります！
 noadjcom:
@@ -231,6 +245,10 @@ vulnerability:
   msg: Toggle Vulnerability
   description:
     msg: Toggles an item's vulnerability state
+blankslot:
+  msg: Nothing here
+  description:
+    msg: Just a placeholder item. Clicking me will not do anything.
 
 #icons (equipment menu)
 disabled:

--- a/src/main/resources/lang/nl_NL.yml
+++ b/src/main/resources/lang/nl_NL.yml
@@ -106,6 +106,20 @@ cantedit:
   msg: Sorry, je kunt hier geen armorstands aanpassen!
 noperm:
   msg: Sorry, je hebt geen tostemming om dit command te gebruiken!
+nopermoption:
+  msg: Sorry, je hebt geen tostemming om <x> optie te gebruiken!
+  basic: Normal ArmorStand
+  showarms: Show Arms
+  armorstandvisibility: Armor Stand Visibility
+  baseplate: Set Baseplate Visibility
+  gravity: Toggle Gravity
+  vulnerability: Toggle Vulnerability!
+  itemframevisibility: Item Frame Visibility
+  size: Toggle ArmorStand Size
+  disableslots: Toggle Equipment Lock
+  paste: Paste ArmorStand Config
+  copy: Copy ArmorStand Config
+  reset: Reset ArmorStand Config
 noslotnumcom:
   msg: Je moet een slot nummer opgeven!
 noadjcom:
@@ -226,6 +240,11 @@ vulnerability:
   msg: Kwetsbaarheid
   description:
     msg: In en uit schakelen van Kwetsbaarheid.
+blankslot:
+  msg: Niets hier
+  description:
+    msg: Gewoon een placeholder item. Op mij klikken zal niets doen.
+
 #icons (equipment menu)
 disabled:
   msg: Uitgeschakeld

--- a/src/main/resources/lang/nl_NL.yml
+++ b/src/main/resources/lang/nl_NL.yml
@@ -70,10 +70,12 @@ nodoubletarget:
   msg: Kijk naar een ArmorStand of een ItemFrame voor je van hand verandert!
 give:
   msg: Speler heeft een item met CustomModelData ontvangen
-notincorrectworld:
-  msg: Sorry, maar uw zijn niet in de juiste wierld om ArmorStandEditor te gebruiken.
 unabledestroycreative:
-  msg: Kan deze Invulnerable ArmorStand niet vernietigen in Creative Modus.
+  msg: Unable to Destroy this Invulnerable ArmorStand in Creative Mode.
+notincorrectworld:
+  msg: Sorry but you are not in the correct world to use ArmorStandEditor.
+playerheadhelp:
+  msg: "Please use /ase playerhead <name> to get a players head. Ex of the command - /ase playerhead Wolfieheart_"
 #Help
 help:
   msg: "1. Houd het wijzigingsgereedschap (<x>) in uw hoofdhand.
@@ -101,6 +103,9 @@ playerhead:
   msg: Player Head opgehaald.
 playerheaderror:
   msg: Probleem om Player Head af te halen.
+stats:
+  msg: Here are the statistics for your ArmorStand.
+
 #warn
 cantedit:
   msg: Sorry, je kunt hier geen armorstands aanpassen!
@@ -120,6 +125,10 @@ nopermoption:
   paste: Paste ArmorStand Config
   copy: Copy ArmorStand Config
   reset: Reset ArmorStand Config
+  stats: View ArmorStand Statistics
+  armorstandglow: Toggle ArmorStand Glow
+norangestats:
+  msg: Please get next to an ArmorStand before running this command.
 noslotnumcom:
   msg: Je moet een slot nummer opgeven!
 noadjcom:
@@ -240,10 +249,22 @@ vulnerability:
   msg: Kwetsbaarheid
   description:
     msg: In en uit schakelen van Kwetsbaarheid.
-blankslot:
-  msg: Niets hier
+itemframevisible:
+  msg: Itemframe Visibility
   description:
-    msg: Gewoon een placeholder item. Op mij klikken zal niets doen.
+    msg: Toggles an itemframes visibility
+playerheadmenu:
+  msg: Player Head
+  description:
+    msg: Please use /ase playerhead <name>
+blankslot:
+  msg: Nothing here
+  description:
+    msg: Just a placeholder item. Clicking me will not do anything.
+armorstandglow:
+  msg: Toggle ArmorStand Glow
+  description:
+    msg: Turn ArmorStand Glowing on or off.
 
 #icons (equipment menu)
 disabled:

--- a/src/main/resources/lang/nl_NL.yml
+++ b/src/main/resources/lang/nl_NL.yml
@@ -70,7 +70,10 @@ nodoubletarget:
   msg: Kijk naar een ArmorStand of een ItemFrame voor je van hand verandert!
 give:
   msg: Speler heeft een item met CustomModelData ontvangen
-
+notincorrectworld:
+  msg: Sorry, maar uw zijn niet in de juiste wierld om ArmorStandEditor te gebruiken.
+unabledestroycreative:
+  msg: Kan deze Invulnerable ArmorStand niet vernietigen in Creative Modus.
 #Help
 help:
   msg: "1. Houd het wijzigingsgereedschap (<x>) in uw hoofdhand.

--- a/src/main/resources/lang/pl_PL.yml
+++ b/src/main/resources/lang/pl_PL.yml
@@ -84,8 +84,22 @@ unabledestroycreative:
 #warn
 cantedit:
   msg: Nie możesz tego zrobić
-noperm: 
+noperm:
   msg: Nie posiadasz wymaganych uprawnień
+nopermoption:
+  msg: You don't have permission to use the <x> Option!
+  basic: Normal ArmorStand
+  showarms: Show Arms
+  armorstandvisibility: Armor Stand Visibility
+  baseplate: Set Baseplate Visibility
+  gravity: Toggle Gravity
+  vulnerability: Toggle Vulnerability!
+  itemframevisibility: Item Frame Visibility
+  size: Toggle ArmorStand Size
+  disableslots: Toggle Equipment Lock
+  paste: Paste ArmorStand Config
+  copy: Copy ArmorStand Config
+  reset: Reset ArmorStand Config
 noslotnumcom: 
   msg: Musisz wybrać slot!
 noadjcom:
@@ -208,6 +222,10 @@ helpgui:
   msg: Pomocy!
   description:
     msg: Kliknij tutaj, aby dostać pomoc!
+blankslot:
+  msg: Nothing here
+  description:
+    msg: Just a placeholder item. Clicking me will not do anything.
 
 #icons (equipment menu)
 disabled: 

--- a/src/main/resources/lang/pl_PL.yml
+++ b/src/main/resources/lang/pl_PL.yml
@@ -77,6 +77,10 @@ noplayerhead:
   msg: Please turn on the ability to retrieve player heads in the config file.
 playerheaderror:
   msg: Unable to Retrieve Player Head.
+notincorrectworld:
+  msg: Sorry but you are not in the correct world to use ArmorStandEditor.
+unabledestroycreative:
+  msg: Unable to Destroy this Invulnerable ArmorStand in Creative Mode.
 #warn
 cantedit:
   msg: Nie możesz tego zrobić

--- a/src/main/resources/lang/pl_PL.yml
+++ b/src/main/resources/lang/pl_PL.yml
@@ -81,6 +81,8 @@ notincorrectworld:
   msg: Sorry but you are not in the correct world to use ArmorStandEditor.
 unabledestroycreative:
   msg: Unable to Destroy this Invulnerable ArmorStand in Creative Mode.
+stats:
+  msg: Here are the statistics for your ArmorStand.
 #warn
 cantedit:
   msg: Nie możesz tego zrobić
@@ -100,6 +102,10 @@ nopermoption:
   paste: Paste ArmorStand Config
   copy: Copy ArmorStand Config
   reset: Reset ArmorStand Config
+  stats: View ArmorStand Statistics
+  armorstandglow: Toggle ArmorStand Glow
+norangestats:
+  msg: Please get next to an ArmorStand before running this command.
 noslotnumcom: 
   msg: Musisz wybrać slot!
 noadjcom:
@@ -222,10 +228,22 @@ helpgui:
   msg: Pomocy!
   description:
     msg: Kliknij tutaj, aby dostać pomoc!
+itemframevisible:
+  msg: Itemframe Visibility
+  description:
+    msg: Toggles an itemframes visibility
+playerheadmenu:
+  msg: Player Head
+  description:
+    msg: Please use /ase playerhead <name>
 blankslot:
   msg: Nothing here
   description:
     msg: Just a placeholder item. Clicking me will not do anything.
+armorstandglow:
+  msg: Toggle ArmorStand Glow
+  description:
+    msg: Turn ArmorStand Glowing on or off.
 
 #icons (equipment menu)
 disabled: 

--- a/src/main/resources/lang/pt_BR.yml
+++ b/src/main/resources/lang/pt_BR.yml
@@ -119,6 +119,10 @@ noplayerhead:
   msg: Please turn on the ability to retrieve player heads in the config file.
 playerheaderror:
   msg: Unable to Retrieve Player Head.
+notincorrectworld:
+  msg: Sorry but you are not in the correct world to use ArmorStandEditor.
+unabledestroycreative:
+  msg: Unable to Destroy this Invulnerable ArmorStand in Creative Mode.
 #menutitle
 mainmenutitle:
   msg: Editor do suporte de armaduras

--- a/src/main/resources/lang/pt_BR.yml
+++ b/src/main/resources/lang/pt_BR.yml
@@ -101,6 +101,20 @@ cantedit:
   msg: Sorry, you cannot edit armor stands here!
 noperm:
   msg: You don't have permission to use this!
+nopermoption:
+  msg: You don't have permission to use the <x> Option!
+  basic: Normal ArmorStand
+  showarms: Show Arms
+  armorstandvisibility: Armor Stand Visibility
+  baseplate: Set Baseplate Visibility
+  gravity: Toggle Gravity
+  vulnerability: Toggle Vulnerability!
+  itemframevisibility: Item Frame Visibility
+  size: Toggle ArmorStand Size
+  disableslots: Toggle Equipment Lock
+  paste: Paste ArmorStand Config
+  copy: Copy ArmorStand Config
+  reset: Reset ArmorStand Config
 noslotnumcom:
   msg: You must specify a slot number!
 noadjcom:
@@ -238,6 +252,10 @@ vulnerability:
   msg: Toggle Vulnerability
   description:
     msg: Toggles an item's vulnerability state
+blankslot:
+  msg: Nothing here
+  description:
+    msg: Just a placeholder item. Clicking me will not do anything.
 
 #icons (equipment menu)
 disabled:

--- a/src/main/resources/lang/pt_BR.yml
+++ b/src/main/resources/lang/pt_BR.yml
@@ -96,6 +96,9 @@ helpurl:
   msg: "More info: https://github.com/RypoFalem/ArmorStandEditor/wiki"
 helpdiscord:
   msg: "or join our Discord: https://discord.gg/3BbJKWpTCj"
+stats:
+  msg: Here are the statistics for your ArmorStand.
+
 #warn
 cantedit:
   msg: Sorry, you cannot edit armor stands here!
@@ -115,6 +118,10 @@ nopermoption:
   paste: Paste ArmorStand Config
   copy: Copy ArmorStand Config
   reset: Reset ArmorStand Config
+  stats: View ArmorStand Statistics
+  armorstandglow: Toggle ArmorStand Glow
+norangestats:
+  msg: Please get next to an ArmorStand before running this command.
 noslotnumcom:
   msg: You must specify a slot number!
 noadjcom:
@@ -248,14 +255,18 @@ itemframevisible:
   msg: Itemframe Visibility
   description:
     msg: Toggles an itemframes visibility
-vulnerability:
-  msg: Toggle Vulnerability
+playerheadmenu:
+  msg: Player Head
   description:
-    msg: Toggles an item's vulnerability state
+    msg: Please use /ase playerhead <name>
 blankslot:
   msg: Nothing here
   description:
     msg: Just a placeholder item. Clicking me will not do anything.
+armorstandglow:
+  msg: Toggle ArmorStand Glow
+  description:
+    msg: Turn ArmorStand Glowing on or off.
 
 #icons (equipment menu)
 disabled:

--- a/src/main/resources/lang/ro_RO.yml
+++ b/src/main/resources/lang/ro_RO.yml
@@ -74,8 +74,22 @@ noplayerhead:
 #warn
 cantedit:
   msg: Nu poti edita armorstand-ul aici!
-noperm: 
+noperm:
   msg: Nu ai permisiunea sa folosesti asta!
+nopermoption:
+  msg: You don't have permission to use the <x> Option!
+  basic: Normal ArmorStand
+  showarms: Show Arms
+  armorstandvisibility: Armor Stand Visibility
+  baseplate: Set Baseplate Visibility
+  gravity: Toggle Gravity
+  vulnerability: Toggle Vulnerability!
+  itemframevisibility: Item Frame Visibility
+  size: Toggle ArmorStand Size
+  disableslots: Toggle Equipment Lock
+  paste: Paste ArmorStand Config
+  copy: Copy ArmorStand Config
+  reset: Reset ArmorStand Config
 noslotnumcom: 
   msg: Trebuie sa specifici numarul unui slot.
 noadjcom:
@@ -200,6 +214,10 @@ vulnerability:
   msg: Toggle Vulnerability
   description:
     msg: Toggles an item's vulnerability state
+blankslot:
+  msg: Nothing here
+  description:
+    msg: Just a placeholder item. Clicking me will not do anything.
 
 #icons (equipment)
 disabled: 

--- a/src/main/resources/lang/ro_RO.yml
+++ b/src/main/resources/lang/ro_RO.yml
@@ -88,7 +88,10 @@ nogive:
   msg: You have no permission to use the give command!
 playerheaderror:
   msg: Unable to Retrieve Player Head.
-
+notincorrectworld:
+  msg: Sorry but you are not in the correct world to use ArmorStandEditor.
+unabledestroycreative:
+  msg: Unable to Destroy this Invulnerable ArmorStand in Creative Mode.
 #menutitle
 mainmenutitle:
   msg: Armor Stand Editor Menu

--- a/src/main/resources/lang/ro_RO.yml
+++ b/src/main/resources/lang/ro_RO.yml
@@ -70,6 +70,8 @@ playerhead:
   msg: Player Head retrieved.
 noplayerhead:
   msg: Please turn on the ability to retrieve player heads in the config file.
+stats:
+  msg: Here are the statistics for your ArmorStand.
 
 #warn
 cantedit:
@@ -90,6 +92,10 @@ nopermoption:
   paste: Paste ArmorStand Config
   copy: Copy ArmorStand Config
   reset: Reset ArmorStand Config
+  stats: View ArmorStand Statistics
+  armorstandglow: Toggle ArmorStand Glow
+norangestats:
+  msg: Please get next to an ArmorStand before running this command.
 noslotnumcom: 
   msg: Trebuie sa specifici numarul unui slot.
 noadjcom:
@@ -214,10 +220,22 @@ vulnerability:
   msg: Toggle Vulnerability
   description:
     msg: Toggles an item's vulnerability state
+itemframevisible:
+  msg: Itemframe Visibility
+  description:
+    msg: Toggles an itemframes visibility
+playerheadmenu:
+  msg: Player Head
+  description:
+    msg: Please use /ase playerhead <name>
 blankslot:
   msg: Nothing here
   description:
     msg: Just a placeholder item. Clicking me will not do anything.
+armorstandglow:
+  msg: Toggle ArmorStand Glow
+  description:
+    msg: Turn ArmorStand Glowing on or off.
 
 #icons (equipment)
 disabled: 

--- a/src/main/resources/lang/ru_RU.yml
+++ b/src/main/resources/lang/ru_RU.yml
@@ -117,7 +117,10 @@ noplayerhead:
   msg: Please turn on the ability to retrieve player heads in the config file.
 playerheaderror:
   msg: Unable to Retrieve Player Head.
-
+notincorrectworld:
+  msg: Sorry but you are not in the correct world to use ArmorStandEditor.
+unabledestroycreative:
+  msg: Unable to Destroy this Invulnerable ArmorStand in Creative Mode.
 #menutitle
 mainmenutitle:
   msg: Редактирование стойки

--- a/src/main/resources/lang/ru_RU.yml
+++ b/src/main/resources/lang/ru_RU.yml
@@ -99,6 +99,20 @@ cantedit:
   msg: Вы не можете редактировать стойки тут
 noperm:
   msg: У вас нет прав, чтобы использовать эту команду
+nopermoption:
+  msg: You don't have permission to use the <x> Option!
+  basic: Normal ArmorStand
+  showarms: Show Arms
+  armorstandvisibility: Armor Stand Visibility
+  baseplate: Set Baseplate Visibility
+  gravity: Toggle Gravity
+  vulnerability: Toggle Vulnerability!
+  itemframevisibility: Item Frame Visibility
+  size: Toggle ArmorStand Size
+  disableslots: Toggle Equipment Lock
+  paste: Paste ArmorStand Config
+  copy: Copy ArmorStand Config
+  reset: Reset ArmorStand Config
 noslotnumcom:
   msg: Укажите номер слота (1-9)
 noadjcom:
@@ -236,6 +250,10 @@ vulnerability:
   msg: Toggle Vulnerability
   description:
     msg: Toggles an item's vulnerability state
+blankslot:
+  msg: Nothing here
+  description:
+    msg: Just a placeholder item. Clicking me will not do anything.
 
 #icons (equipment menu)
 disabled:

--- a/src/main/resources/lang/ru_RU.yml
+++ b/src/main/resources/lang/ru_RU.yml
@@ -93,6 +93,8 @@ helpdiscord:
   msg: "or join our Discord: https://discord.gg/3BbJKWpTCj"
 give:
   msg: Player given Item with CustomModelData
+stats:
+  msg: Here are the statistics for your ArmorStand.
 
 #warn
 cantedit:
@@ -113,6 +115,10 @@ nopermoption:
   paste: Paste ArmorStand Config
   copy: Copy ArmorStand Config
   reset: Reset ArmorStand Config
+  stats: View ArmorStand Statistics
+  armorstandglow: Toggle ArmorStand Glow
+norangestats:
+  msg: Please get next to an ArmorStand before running this command.
 noslotnumcom:
   msg: Укажите номер слота (1-9)
 noadjcom:
@@ -246,14 +252,18 @@ itemframevisible:
   msg: Видимость рамки
   description:
     msg: Включить или выключить видимость рамки
-vulnerability:
-  msg: Toggle Vulnerability
+playerheadmenu:
+  msg: Player Head
   description:
-    msg: Toggles an item's vulnerability state
+    msg: Please use /ase playerhead <name>
 blankslot:
   msg: Nothing here
   description:
     msg: Just a placeholder item. Clicking me will not do anything.
+armorstandglow:
+  msg: Toggle ArmorStand Glow
+  description:
+    msg: Turn ArmorStand Glowing on or off.
 
 #icons (equipment menu)
 disabled:

--- a/src/main/resources/lang/ru_RU.yml
+++ b/src/main/resources/lang/ru_RU.yml
@@ -1,4 +1,4 @@
-# Translated by KPidS
+# Translated by KPidS+Hopak120
 
 iconname: 2n
 icondescription: 5
@@ -20,7 +20,7 @@ setmode:
   invisible: переключения видимости
   size: переключения размера
   disableslots: переключения блокировки снаряжения
-  vulnerability: Toggle Vulnerability
+  vulnerability: переключения неуязвимости
   gravity: переключения гравитации
   baseplate: переключения плиты
   placement: изменения расположения
@@ -59,15 +59,15 @@ target:
 notarget:
   msg: Цель стойки разблокирована
 toggleinvulnerability:
-  msg: ArmorStand vulnerability state has been toggled to <x>.
-  true: invulnerable
-  false: vulnerable
+  msg: Стойка стала <x>.
+  true: неуязвимой
+  false: уязвимой
 frametarget:
   msg: Цель рамки заблокирована
 doubletarget:
   msg: Наведитесь на стойку или на рамку, а не на то и другое одновременно.
 nodoubletarget:
-  msg: Please look at an ArmorStand or an ItemFrame before switching hands!
+  msg: Пожалуйста, смотрите на стойку или на рамку прежде чем менять руки!
 reloaded:
   msg: Конфиг перезагружен.
 help:
@@ -90,35 +90,15 @@ helptips:
 helpurl:
   msg: "Больше информации: https://github.com/RypoFalem/ArmorStandEditor/wiki"
 helpdiscord:
-  msg: "or join our Discord: https://discord.gg/3BbJKWpTCj"
+  msg: "или присоединитесь к нашему Discord: https://discord.gg/3BbJKWpTCj"
 give:
-  msg: Player given Item with CustomModelData
-stats:
-  msg: Here are the statistics for your ArmorStand.
+  msg: Игроку выдан предмет с CustomModelData.
 
 #warn
 cantedit:
   msg: Вы не можете редактировать стойки тут
 noperm:
   msg: У вас нет прав, чтобы использовать эту команду
-nopermoption:
-  msg: You don't have permission to use the <x> Option!
-  basic: Normal ArmorStand
-  showarms: Show Arms
-  armorstandvisibility: Armor Stand Visibility
-  baseplate: Set Baseplate Visibility
-  gravity: Toggle Gravity
-  vulnerability: Toggle Vulnerability!
-  itemframevisibility: Item Frame Visibility
-  size: Toggle ArmorStand Size
-  disableslots: Toggle Equipment Lock
-  paste: Paste ArmorStand Config
-  copy: Copy ArmorStand Config
-  reset: Reset ArmorStand Config
-  stats: View ArmorStand Statistics
-  armorstandglow: Toggle ArmorStand Glow
-norangestats:
-  msg: Please get next to an ArmorStand before running this command.
 noslotnumcom:
   msg: Укажите номер слота (1-9)
 noadjcom:
@@ -130,17 +110,14 @@ nomodecom:
 noreloadcom:
   msg: У вас нет прав, чтобы использовать эту команду
 nogive:
-  msg: You have no permission to use the give command!
+  msg: У вас нет прав на команду give
 playerhead:
-  msg: Player Head retrieved.
+  msg: Получена голова игрока.
 noplayerhead:
-  msg: Please turn on the ability to retrieve player heads in the config file.
+  msg: Пожалуйста включите возможность получения головы игрока в конфиге.
 playerheaderror:
-  msg: Unable to Retrieve Player Head.
-notincorrectworld:
-  msg: Sorry but you are not in the correct world to use ArmorStandEditor.
-unabledestroycreative:
-  msg: Unable to Destroy this Invulnerable ArmorStand in Creative Mode.
+  msg: Невозможно получить голову игрока
+
 #menutitle
 mainmenutitle:
   msg: Редактирование стойки
@@ -252,18 +229,10 @@ itemframevisible:
   msg: Видимость рамки
   description:
     msg: Включить или выключить видимость рамки
-playerheadmenu:
-  msg: Player Head
+vulnerability:
+  msg: Неуязвимость
   description:
-    msg: Please use /ase playerhead <name>
-blankslot:
-  msg: Nothing here
-  description:
-    msg: Just a placeholder item. Clicking me will not do anything.
-armorstandglow:
-  msg: Toggle ArmorStand Glow
-  description:
-    msg: Turn ArmorStand Glowing on or off.
+    msg: Включить или выключить неуязвимость
 
 #icons (equipment menu)
 disabled:
@@ -276,7 +245,7 @@ equipslot:
     chest: нагрудник
     pants: штаны
     boots: ботинки
-    rhand: предмет для правой руки 
+    rhand: предмет для правой руки
     lhand: предмет для левой руки
   helm: Шлем
   chest: Нагрудник

--- a/src/main/resources/lang/test_NA.yml
+++ b/src/main/resources/lang/test_NA.yml
@@ -55,8 +55,20 @@ pasted:
 #warn
 cantedit:
   msg: Sorry, you cannot edit armor stands here!
-noperm: 
-  msg: You don't have permission to use this!
+noperm:
+  msg: You don't have permission to use the <x> Option!
+  basic: Normal ArmorStand
+  showarms: Show Arms
+  armorstandvisibility: Armor Stand Visibility
+  baseplate: Set Baseplate Visibility
+  gravity: Toggle Gravity
+  vulnerability: Toggle Vulnerability!
+  itemframevisibility: Item Frame Visibility
+  size: Toggle ArmorStand Size
+  disableslots: Toggle Equipment Lock
+  paste: Paste ArmorStand Config
+  copy: Copy ArmorStand Config
+  reset: Reset ArmorStand Config
 noslotnumcom: 
   msg: You must specify a slot number!
 noadjcom:
@@ -182,7 +194,10 @@ copyslot:
   msg: Copy Slot <x>
   description:
     msg: Select a slot to store settings
-
+blankslot:
+  msg: Nothing here
+  description:
+    msg: Just a placeholder item. Clicking me will not do anything.
 #icons (equipment)
 disabled: 
   msg: Disabled

--- a/src/main/resources/lang/test_NA.yml
+++ b/src/main/resources/lang/test_NA.yml
@@ -75,7 +75,10 @@ toggleinvulnerability:
   msg: ArmorStand vulnerability state has been toggled to <x>.
   true: invulnerable
   false: vulnerable
-
+notincorrectworld:
+  msg: Sorry but you are not in the correct world to use ArmorStandEditor.
+unabledestroycreative:
+  msg: Unable to Destroy this Invulnerable ArmorStand in Creative Mode.
 #menutitle
 mainmenutitle:
   msg: Armor Stand Editor Menu

--- a/src/main/resources/lang/uk_UA.yml
+++ b/src/main/resources/lang/uk_UA.yml
@@ -70,7 +70,10 @@ noplayerhead:
   msg: Please turn on the ability to retrieve player heads in the config file.
 playerheaderror:
   msg: Unable to Retrieve Player Head.
-
+notincorrectworld:
+  msg: Sorry but you are not in the correct world to use ArmorStandEditor.
+unabledestroycreative:
+  msg: Unable to Destroy this Invulnerable ArmorStand in Creative Mode.
 #warn  
 cantedit:
   msg: Ти не можеш змінювати стенди тут!

--- a/src/main/resources/lang/uk_UA.yml
+++ b/src/main/resources/lang/uk_UA.yml
@@ -74,6 +74,8 @@ notincorrectworld:
   msg: Sorry but you are not in the correct world to use ArmorStandEditor.
 unabledestroycreative:
   msg: Unable to Destroy this Invulnerable ArmorStand in Creative Mode.
+stats:
+  msg: Here are the statistics for your ArmorStand.
 #warn  
 cantedit:
   msg: Ти не можеш змінювати стенди тут!
@@ -93,6 +95,10 @@ nopermoption:
   paste: Paste ArmorStand Config
   copy: Copy ArmorStand Config
   reset: Reset ArmorStand Config
+  stats: View ArmorStand Statistics
+  armorstandglow: Toggle ArmorStand Glow
+norangestats:
+  msg: Please get next to an ArmorStand before running this command.
 noslotnumcom:
   msg: Уточніть слот!
 noadjcom:
@@ -207,10 +213,23 @@ vulnerability:
   msg: Toggle Vulnerability
   description:
     msg: Toggles an item's vulnerability state
+itemframevisible:
+  msg: Itemframe Visibility
+  description:
+    msg: Toggles an itemframes visibility
+playerheadmenu:
+  msg: Player Head
+  description:
+    msg: Please use /ase playerhead <name>
 blankslot:
   msg: Nothing here
   description:
     msg: Just a placeholder item. Clicking me will not do anything.
+armorstandglow:
+  msg: Toggle ArmorStand Glow
+  description:
+    msg: Turn ArmorStand Glowing on or off.
+
 #icons (equipment)
 disabled:
   msg: Вимкнено

--- a/src/main/resources/lang/uk_UA.yml
+++ b/src/main/resources/lang/uk_UA.yml
@@ -79,6 +79,20 @@ cantedit:
   msg: Ти не можеш змінювати стенди тут!
 noperm:
   msg: У тебе нема прав!
+nopermoption:
+  msg: You don't have permission to use the <x> Option!
+  basic: Normal ArmorStand
+  showarms: Show Arms
+  armorstandvisibility: Armor Stand Visibility
+  baseplate: Set Baseplate Visibility
+  gravity: Toggle Gravity
+  vulnerability: Toggle Vulnerability!
+  itemframevisibility: Item Frame Visibility
+  size: Toggle ArmorStand Size
+  disableslots: Toggle Equipment Lock
+  paste: Paste ArmorStand Config
+  copy: Copy ArmorStand Config
+  reset: Reset ArmorStand Config
 noslotnumcom:
   msg: Уточніть слот!
 noadjcom:
@@ -193,7 +207,10 @@ vulnerability:
   msg: Toggle Vulnerability
   description:
     msg: Toggles an item's vulnerability state
-
+blankslot:
+  msg: Nothing here
+  description:
+    msg: Just a placeholder item. Clicking me will not do anything.
 #icons (equipment)
 disabled:
   msg: Вимкнено

--- a/src/main/resources/lang/zh_CN.yml
+++ b/src/main/resources/lang/zh_CN.yml
@@ -112,6 +112,20 @@ cantedit:
   msg: 对不起, 你无法在这里编辑盔甲架!
 noperm:
   msg: 你没有权限这样做!
+nopermoption:
+  msg: You don't have permission to use the <x> Option!
+  basic: Normal ArmorStand
+  showarms: Show Arms
+  armorstandvisibility: Armor Stand Visibility
+  baseplate: Set Baseplate Visibility
+  gravity: Toggle Gravity
+  vulnerability: Toggle Vulnerability!
+  itemframevisibility: Item Frame Visibility
+  size: Toggle ArmorStand Size
+  disableslots: Toggle Equipment Lock
+  paste: Paste ArmorStand Config
+  copy: Copy ArmorStand Config
+  reset: Reset ArmorStand Config
 noslotnumcom:
   msg: 你必须选择一个物品栏!
 noadjcom:
@@ -236,7 +250,10 @@ itemframevisible:
   msg: 物品展示框显隐切换
   description:
     msg: 显示/隐形物品展示框
-    
+blankslot:
+  msg: Nothing here
+  description:
+    msg: Just a placeholder item. Clicking me will not do anything.
 #图标 (装备)
 disabled:
   msg: 关闭

--- a/src/main/resources/lang/zh_CN.yml
+++ b/src/main/resources/lang/zh_CN.yml
@@ -106,6 +106,8 @@ notincorrectworld:
   msg: Sorry but you are not in the correct world to use ArmorStandEditor.
 unabledestroycreative:
   msg: Unable to Destroy this Invulnerable ArmorStand in Creative Mode.
+stats:
+  msg: Here are the statistics for your ArmorStand.
 
 #警告
 cantedit:
@@ -126,6 +128,10 @@ nopermoption:
   paste: Paste ArmorStand Config
   copy: Copy ArmorStand Config
   reset: Reset ArmorStand Config
+  stats: View ArmorStand Statistics
+  armorstandglow: Toggle ArmorStand Glow
+norangestats:
+  msg: Please get next to an ArmorStand before running this command.
 noslotnumcom:
   msg: 你必须选择一个物品栏!
 noadjcom:
@@ -254,6 +260,15 @@ blankslot:
   msg: Nothing here
   description:
     msg: Just a placeholder item. Clicking me will not do anything.
+playerheadmenu:
+  msg: Player Head
+  description:
+    msg: Please use /ase playerhead <name>
+armorstandglow:
+  msg: Toggle ArmorStand Glow
+  description:
+    msg: Turn ArmorStand Glowing on or off.
+
 #图标 (装备)
 disabled:
   msg: 关闭

--- a/src/main/resources/lang/zh_CN.yml
+++ b/src/main/resources/lang/zh_CN.yml
@@ -102,7 +102,10 @@ noplayerhead:
   msg: Please turn on the ability to retrieve player heads in the config file.
 playerheaderror:
   msg: Unable to Retrieve Player Head.
-
+notincorrectworld:
+  msg: Sorry but you are not in the correct world to use ArmorStandEditor.
+unabledestroycreative:
+  msg: Unable to Destroy this Invulnerable ArmorStand in Creative Mode.
 #警告
 cantedit:
   msg: 对不起,你无法在这编辑盔甲架!

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -86,6 +86,9 @@ permissions:
   asedit.togglegravity:
     description: Changes whether the armor stand has gravity
     default: true
+  asedit.togglearmorstandglow:
+    description: Allows toggling of the Glowing State of an ArmorStand.
+    default: true
   asedit.stats:
     description: Ability to view ArmorStand Stats.
     default: true
@@ -162,6 +165,7 @@ permissions:
       asedit.togglesize: true
       asedit.togglearmorstandvisibility: true
       asedit.toggleitemframevisibility: true
+      asedit.togglearmorstandglow: true
       asedit.permpack.dontIgnoreProtections: true
 
   asedit.permpack.admin:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: ArmorStandEditor
 main: io.github.rypofalem.armorstandeditor.ArmorStandEditorPlugin
-version: 1.20.2-44
+version: 1.20.x-44
 api-version: "1.17"
 folia-supported: true
 website: https://www.spigotmc.org/resources/94503/

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: ArmorStandEditor
 main: io.github.rypofalem.armorstandeditor.ArmorStandEditorPlugin
-version: 1.20.1-44
+version: 1.20.2-44
 api-version: "1.17"
 folia-supported: true
 website: https://www.spigotmc.org/resources/94503/

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: ArmorStandEditor
 main: io.github.rypofalem.armorstandeditor.ArmorStandEditorPlugin
-version: 1.20.1-44
+version: 1.20.1-43.2
 api-version: "1.17"
 folia-supported: true
 website: https://www.spigotmc.org/resources/94503/

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -86,6 +86,10 @@ permissions:
     description: Changes whether the armor stand has gravity
     default: false
 
+  asedit.disableCreativeBreak:
+    description: Disables breaking of ArmorStands in Creative Mode
+    default: false
+
   asedit.ignoreProtection.towny:
     description: Allows user to ignore Towny's Protection Limitations.
     default: false

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -86,10 +86,6 @@ permissions:
     description: Changes whether the armor stand has gravity
     default: false
 
-  asedit.disableCreativeBreak:
-    description: Disables breaking of ArmorStands in Creative Mode
-    default: false
-
   asedit.ignoreProtection.towny:
     description: Allows user to ignore Towny's Protection Limitations.
     default: false

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -31,13 +31,13 @@ permissions:
     default: true
   asedit.rename:
     description: Rename armorstands - Now Supports Color
-    default: false
+    default: true
   asedit.equipment:
     description: Access armorstand equipment GUI
-    default: false
+    default: true
   asedit.disableSlots:
     description: Allows locking and unlocking the contents of an ArmorStand. When locked, armor and equipment can not be added or removed without unlocking it first.
-    default: false
+    default: true
   asedit.give:
     description: Gives player the EditTool with Proper CustomModelData
     default: false
@@ -52,10 +52,10 @@ permissions:
     default: false
   asedit.movement:
     description: Changes whether the armor stand can be moved using the item for editing
-    default: false
+    default: true
   asedit.rotation:
     description: Allows player to rotate the ArmorStand
-    default: false
+    default: true
   asedit.copy:
     description: Allows the players to create copies of their ArmorStand Configurations.
     default: false
@@ -64,28 +64,31 @@ permissions:
     default: false
   asedit.reset:
     description: Allows the reset of the ArmorStand back to Default values
-    default: false
+    default: true
   asedit.togglearmorstandvisibility:
     description: Toggles ArmorStand visibility.
-    default: false
+    default: true
   asedit.toggleitemframevisibility:
     description: Allows setting of ItemFrame Visibility
-    default: false
+    default: true
   asedit.toggleInvulnerability:
     description: Allows players to toggle the vulnerability state of an ArmorStand.
-    default: false
+    default: true
   asedit.togglebaseplate:
     description: Allows the toggling of the Baseplate of an ArmorStand.
-    default: false
+    default: true
   asedit.togglearms:
     description: Allows the toggling of the Arms of an ArmorStand.
-    default: false
+    default: true
   asedit.togglesize:
     description: Allows the toggling of the size of an ArmorStand.
-    default: false
+    default: true
   asedit.togglegravity:
     description: Changes whether the armor stand has gravity
-    default: false
+    default: true
+  asedit.stats:
+    description: Ability to view ArmorStand Stats.
+    default: true
 
   asedit.ignoreProtection.towny:
     description: Allows user to ignore Towny's Protection Limitations.

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -24,6 +24,7 @@ permissions:
     children:
       asedit.permpack.admin: true
       asedit.ignoreProtection.*: true
+      asedit.head: true
 
   asedit.basic:
     description: Allow use armorstand edit functions. If set to false it will override all other functions.

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: ArmorStandEditor
 main: io.github.rypofalem.armorstandeditor.ArmorStandEditorPlugin
-version: 1.20.1-43.2
+version: 1.20.1-44
 api-version: "1.17"
 folia-supported: true
 website: https://www.spigotmc.org/resources/94503/

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: ArmorStandEditor
 main: io.github.rypofalem.armorstandeditor.ArmorStandEditorPlugin
 version: 1.20.1-43.2
-api-version: "1.13"
+api-version: "1.17"
 folia-supported: true
 website: https://www.spigotmc.org/resources/94503/
 author: Wolfstorm

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,11 +1,11 @@
 name: ArmorStandEditor
 main: io.github.rypofalem.armorstandeditor.ArmorStandEditorPlugin
-version: 1.20.x-44
+version: 1.20.2-44
 api-version: "1.17"
 folia-supported: true
 website: https://www.spigotmc.org/resources/94503/
 author: Wolfstorm
-authors: [Wolfstorm, Pinnkk, Kugge, Marfjeh, miknes123, rypofalem, sekwah41, Sikatsu1997, Cool_boy, sumdream, Amaury Carrade, nicuch, kotarobo, prettydude, Jumpy91, Niasio, Patbox, Puremin0rez, Prof-Bloodstone, PlanetTeamSpeak]
+authors: [Wolfstorm, DreiFxn, Pinnkk, Kugge, Marfjeh, miknes123, rypofalem, sekwah41, Sikatsu1997, Cool_boy, sumdream, Amaury Carrade, nicuch, kotarobo, prettydude, Jumpy91, Niasio, Patbox, Puremin0rez, Prof-Bloodstone, PlanetTeamSpeak]
 description: Allows players to edit data of armorstands without any commands.
 softdepend: [Towny, WorldGuard, GriefPrevention, PlotSquared, Lands, bentobox]
 


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the ArmorStandEditor project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect ArmorStandEditor, making your code available to us to use indefinitely. --->
#### Description:
<!--- Describe your Pull Request's purpose here please. --->
## Important Changes
- Upgrade to 1.17 APIs going forward -> See the last release [changelog](https://www.spigotmc.org/resources/armorstandeditor-reborn.94503/update?update=512835) for more info as to why we are doing this
- Per World Support for ArmorStandEditor
- Refactoring of the Plot2 Protection
  - Now supports checks to prevent players from moving ArmorStands out to roads
- New UI: #DreiFxn 
![image](https://github.com/Wolfieheart/ArmorStandEditor/assets/18635695/0650fb58-8849-41a9-9299-5630baebd5d2)
- Glowing Support via `asedit.togglearmorstandglow`
- Introduction of `asedit.stats` and `/asedit stats` to get the statistics of an ArmorStand
- Updated Translations

##  Fixes
- Fix #309 when destroying Invulnerable ArmorStands in Creative Mode
- Fix for Colored Names when ArmorStands are broken and replaced
----
### [CORE] Changes
*Changes to the core of the plugin - Performance Fixes, Bug Fixes, New Features, New Permission Nodes, New Config Options etc.* 
<!---- List your changes under this in a bullet point list --->



----
### [CI] Changes
*Changes relating to the Continuous Integration of other Plugin APIs, Github Workflows, Issue Templates etc.*
<!---- List your changes under this in a bullet point list --->

----
### [DOC] Changes
*Changes relating to plugin Documentation - See the Wiki for more info*
<!---- List your changes under this in a bullet point list --->

----
### [MISC] Changes
*Changes that does not fit in the above list*
<!---- List your changes under this in a bullet point list --->


____
- [ ] I have tested this pull request for defects on a server.
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the ArmorStandEditor Project Owners have the copyright to use and modify my contribution under the ArmorStandEditor [License](https://github.com/Wolfieheart/ArmorStandEditor/blob/master/LICENSE.md) for perpetuity.