### PR TITLE
Reworking protection system (test-event & move-location check)

### DIFF
--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
@@ -282,6 +282,10 @@ public class PlayerEditor {
                 loc.add(0, 0, movChange);
                 break;
         }
+        
+        // Checking the building permission for the target location:
+        if (!PlayerEditorManager.canEdit(getPlayer(), loc)) return;
+        
         Scheduler.teleport(armorStand, loc);
     }
 
@@ -299,6 +303,10 @@ public class PlayerEditor {
                 loc.subtract(0, 0, movChange);
                 break;
         }
+        
+        // Checking the building permission for the target location:
+        if (!PlayerEditorManager.canEdit(getPlayer(), loc)) return;
+        
         Scheduler.teleport(armorStand, loc);
     }
 

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
@@ -339,10 +339,10 @@ public class PlayerEditorManager implements Listener {
     }
     
     static boolean canEdit(Player player, Location location) {
-        // Get the Entity being checked for editing
         Block block = location.getBlock();
         
-        // TODO Remove old protection system, including "protections/" folder and documentation update:
+        // TODO Deconstruct unused restriction-system checks in "protections/" folder. 
+        //  Only 'asedit.ignoreProtection.<plugin>' check is necessary now.
         
 /*        // Check if all protections allow this edit, if one fails, don't allow edit
         return protections.stream().allMatch(protection -> protection.checkPermission(block, player));*/

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
@@ -20,18 +20,19 @@
 package io.github.rypofalem.armorstandeditor;
 
 import com.google.common.collect.ImmutableList;
-
 import io.github.rypofalem.armorstandeditor.api.ArmorStandRenameEvent;
 import io.github.rypofalem.armorstandeditor.api.ItemFrameGlowEvent;
 import io.github.rypofalem.armorstandeditor.menu.ASEHolder;
 import io.github.rypofalem.armorstandeditor.protections.*;
-
 import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.entity.*;
-import org.bukkit.event.*;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
+import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
@@ -333,13 +334,29 @@ public class PlayerEditorManager implements Listener {
         return itemFrames;
     }
 
-
-    boolean canEdit(Player player, Entity entity) {
-        //Get the Entity being checked for editing
-        Block block = entity.getLocation().getBlock();
-
-        // Check if all protections allow this edit, if one fails, don't allow edit
-        return protections.stream().allMatch(protection -> protection.checkPermission(block, player));
+    static boolean canEdit(Player player, Entity entity) {
+        return canEdit(player, entity.getLocation());
+    }
+    
+    static boolean canEdit(Player player, Location location) {
+        // Get the Entity being checked for editing
+        Block block = location.getBlock();
+        
+        // TODO Remove old protection system, including "protections/" folder and documentation update:
+        
+/*        // Check if all protections allow this edit, if one fails, don't allow edit
+        return protections.stream().allMatch(protection -> protection.checkPermission(block, player));*/
+        
+        // Creating test place-event for the target location (works also for Fine Adjustment):
+        BlockPlaceEvent placeEvent = new BlockPlaceEvent(block, block.getState(), location.getBlock(), 
+                player.getActiveItem(), player, false, player.getActiveItemHand());
+        
+        // Checking build permission by test-event:
+        Bukkit.getServer().getPluginManager().callEvent(placeEvent);
+        boolean canBuild = !placeEvent.isCancelled();
+        placeEvent.setCancelled(true);
+        
+        return canBuild;
     }
 
     void applyLeftTool(Player player, ArmorStand as) {

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
@@ -347,16 +347,16 @@ public class PlayerEditorManager implements Listener {
 /*        // Check if all protections allow this edit, if one fails, don't allow edit
         return protections.stream().allMatch(protection -> protection.checkPermission(block, player));*/
         
-        // Creating test place-event for the target location (works also for Fine Adjustment):
+        // Creating test place-event for the target location. (Works also for Fine Adjustment.)
+        // Used 'BlockPlaceEvent', because e.g. 'EntityPlaceEvent' is not handled the same for every restriction system.
         BlockPlaceEvent placeEvent = new BlockPlaceEvent(block, block.getState(), location.getBlock(), 
                 player.getActiveItem(), player, false, player.getActiveItemHand());
         
-        // Checking build permission by test-event:
+        // Checking build permission by test-event. (The block is generally not placed via 'callEvent()' method.)
         Bukkit.getServer().getPluginManager().callEvent(placeEvent);
-        boolean canBuild = !placeEvent.isCancelled();
-        placeEvent.setCancelled(true);
+        // An event-cancel afterward would have no effect.
         
-        return canBuild;
+        return !placeEvent.isCancelled();
     }
 
     void applyLeftTool(Player player, ArmorStand as) {


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the ArmorStandEditor project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect ArmorStandEditor, making your code available to us to use indefinitely. --->
### Description

With this PR I would like to suggest a different approach to checking building rights. Querying all rights plugins is currently inperformant and not completely correct due to the different scenarios (_e.g. misc flags like `block-build` on WorldGuard; custom flags for WorldGuard & PlotSquared via add-ons; or custom features via add-ons for BentoBox_). At the end, **we are interested in whether the player is allowed to build at the corresponding location or not**, right? So, I used a test event to check whether the player is allowed to build at the current Armorstand position and whether he is allowed to build at the target location of a Move event (if performed).

I can see you had a lot of work to support the large number of protection plugins, but the current test seems to work well. The new check may be more correct for some cases, as it simply reflects the test result and does not refer to the theoretical processes of the individual restriction plugins.

### Some other notes

By movements in the Y-achse the "lower block" is checked here. This is the same behavior as normal building protections (e.g. with WorldGuard).

The only weak point of this concept is that logging systems log the test-event. For example, it's logged by CoreProtect on location **without AIR**, by default. I don't see any good way to get around this.

![grafik](https://github.com/Wolfieheart/ArmorStandEditor/assets/4140635/a682135a-22ef-4f3f-8056-4b7d106cafe8)

Once the restriction has been tested for a while, we can minimize the `/protections` folder. Only the permission check of `asedit.ignoreProtection.<plugin>` would then be necessary. (An OP check is not necessary, as the permission is already queried).

[/src/main/java/io/github/rypofalem/armorstandeditor/protections/WorldGuardProtection.java#L48-L49](https://github.com/RedstoneFuture/ArmorStandEditor/blob/647b74bf9e0c3a4a4676e665b86cee3cbcbcfd36/src/main/java/io/github/rypofalem/armorstandeditor/protections/WorldGuardProtection.java#L48-L49)
```java
        if (player.isOp()) return true;
        if (player.hasPermission("asedit.ignoreProtection.worldGuard")) return true;
```

I would like to point out that I am primarily looking for **the best and safest option**. In this case, it also seems to be the simplest solution. Provided it works equally well with all supported plugins.

----
### [CORE] Changes
*Changes to the core of the plugin - Performance Fixes, Bug Fixes, New Features, New Permission Nodes, New Config Options etc.* 
- Replacing the current permission check with creating of a `BlockPlaceEvent` test event (performance and restriction improvements)
- Adding `canEdit` check for Move and Reverse-Move to prevent armorstands from leaving the region

----
### [CI] Changes
*Changes relating to the Continuous Integration of other Plugin APIs, Github Workflows, Issue Templates etc.*
<!---- List your changes under this in a bullet point list --->

----
### [DOC] Changes
*Changes relating to plugin Documentation - See the Wiki for more info*
<!---- List your changes under this in a bullet point list --->

----
### [MISC] Changes
*Changes that does not fit in the above list*
<!---- List your changes under this in a bullet point list --->


____


### Dev-Test
Tested with:
- PaperMC `1.20.6`
- the changes based of `ArmorStandEditor-Reborn v. 1.20.6-46.2`
- `PlotSquared v. 7.3.8` and `WorldGuard v. 7.0.9` for `X`, `Y` and `Z` movements of armorstands

**I am not familiar with all of the supported protection systems. Please feel free to report any errors you find with other plugins.**

- [X] I have tested this pull request for defects on a server.
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the ArmorStandEditor Project Owners have the copyright to use and modify my contribution under the ArmorStandEditor [License](https://github.com/Wolfieheart/ArmorStandEditor/blob/master/LICENSE.md) for perpetuity.