### PR TITLE
Fix towny integration not finding armor stands to edit

### DIFF
--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
@@ -363,11 +363,8 @@ public class PlayerEditorManager implements Listener {
 
 
     boolean canEdit(Player player, Entity entity) {
-        //Get the Entity being checked for editing
-        Block block = entity.getLocation().getBlock();
-
         // Check if all protections allow this edit, if one fails, don't allow edit
-        return protections.stream().allMatch(protection -> protection.checkPermission(block, player));
+        return protections.stream().allMatch(protection -> protection.checkPermission(entity, player));
     }
 
     void applyLeftTool(Player player, ArmorStand as) {

--- a/src/main/java/io/github/rypofalem/armorstandeditor/protections/Protection.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/protections/Protection.java
@@ -19,8 +19,15 @@
 package io.github.rypofalem.armorstandeditor.protections;
 
 import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 
 public interface Protection {
-    boolean checkPermission(Block block, Player player);
+    default boolean checkPermission(Block block, Player player) {
+        return true;
+    }
+
+    default boolean checkPermission(Entity entity, Player player) {
+        return checkPermission(entity.getLocation().getBlock(), player);
+    }
 }

--- a/src/main/java/io/github/rypofalem/armorstandeditor/protections/TownyProtection.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/protections/TownyProtection.java
@@ -27,11 +27,9 @@ import io.github.rypofalem.armorstandeditor.Debug;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
-import org.bukkit.block.Block;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
-import org.bukkit.util.BoundingBox;
 
 
 //FIX for https://github.com/Wolfieheart/ArmorStandEditor-Issues/issues/15
@@ -47,18 +45,17 @@ public class TownyProtection implements Protection {
         tEnabled = Bukkit.getPluginManager().isPluginEnabled("Towny");
     }
 
-    public boolean checkPermission(Block block, Player player) {
+    @Override
+    public boolean checkPermission(Entity entity, Player player) {
 
         // Bypasses - Towny is not detected, Player is Op or has Bypass Perms
         if (!tEnabled || player.isOp() || player.hasPermission("asedit.ignoreProtection.towny")) return true;
 
         TownyAPI towny = TownyAPI.getInstance();
         Location playerLoc = player.getLocation();
-        Location asLoc = block.getLocation();
 
         // --- Get ArmorStand on the Block --
-        ArmorStand entityOnBlock = findArmorStandOnBlock(asLoc);
-        if (entityOnBlock == null) {
+        if (!(entity instanceof ArmorStand entityOnBlock)) {
             debug.log("No ArmorStand has been found therefore we will continue as intended");
             return true;
         }
@@ -83,27 +80,6 @@ public class TownyProtection implements Protection {
                 Material.ARMOR_STAND,                   // treat the target as an ArmorStand
                 TownyPermission.ActionType.BUILD
         );
-    }
-
-    /**
-     * Utility: finds an ArmorStand sitting directly on top of the given block.
-     */
-    private ArmorStand findArmorStandOnBlock(Location asLoc) {
-        BoundingBox bbox = BoundingBox.of(asLoc, 1, 1, 1).shift(0, 1, 0);
-
-        for (Entity entity : asLoc.getWorld().getNearbyEntities(bbox)){
-            if(entity instanceof ArmorStand stand){
-                Location entityLoc = stand.getLocation();
-                debug.log("ArmorStand Found at X: " + entityLoc.getBlockX() + ", Y: " + entityLoc.getBlockY() + ", Z: " + entityLoc.getBlockZ());
-                if(entityLoc.getBlockX() == asLoc.getBlockX()
-                        && entityLoc.getBlockZ() == asLoc.getBlockZ()
-                        && entityLoc.getBlockY() == asLoc.getBlockY() + 1){
-                    return stand;
-                }
-            }
-        }
-        debug.log("Entity found at X: " + asLoc.getBlockX() + ", Y: " + asLoc.getBlockY()+1 + ", Z: " + asLoc.getBlockZ() +" is not an ArmorStand. So we will return NULL - Will do so for ItemFrames etc.");
-        return null;
     }
 }
 


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the ArmorStandEditor project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect ArmorStandEditor, making your code available to us to use indefinitely. --->
#### Description:
<!--- Describe your Pull Request's purpose here please. --->

Closes https://github.com/Wolfieheart/ArmorStandEditor/issues/787

The cause behind it no longer working was an off by one issue discovered by @Veyronity in the findArmorStandOnBlock method, causing the protection to not find the armor stand and wrongly allow the edit.

This PR fixes that by replacing the aforementioned method with a new method that directly passes the entity instance, removing the need to try and find it.

----
### [CORE] Changes
*Changes to the core of the plugin - Performance Fixes, Bug Fixes, New Features, New Permission Nodes, New Config Options etc.* 
<!---- List your changes under this in a bullet point list --->
- Fixes the Towny integration not working.

____
- [x] I have tested this pull request for defects on a server.
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the ArmorStandEditor Project Owners have the copyright to use and modify my contribution under the ArmorStandEditor [License](https://github.com/Wolfieheart/ArmorStandEditor/blob/master/LICENSE.md) for perpetuity.