### PR TITLE
[CORE] Fix armor stand placement being blocked by EntityPlaceEvent

### DIFF
--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
@@ -109,7 +109,6 @@ public class PlayerEditorManager implements Listener {
                 + ", Z: " + location.getZ());
 
         armorStand.setGravity(plugin.getDefaultGravity());
-        event.setCancelled(true);
     }
 
     @EventHandler(priority = EventPriority.LOWEST)


### PR DESCRIPTION
players were unable to place armor stands due to the event being cancelled in the onArmorStandSpawn handler. The event cancellation was preventing placement while trying to set defualt gravity

<!--- Welcome! It looks like you're opening a pull request for the ArmorStandEditor project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect ArmorStandEditor, making your code available to us to use indefinitely. --->
#### Description:
<!--- Describe your Pull Request's purpose here please. --->

----
### [CORE] Changes
*Changes to the core of the plugin - Performance Fixes, Bug Fixes, New Features, New Permission Nodes, New Config Options etc.* 
<!---- List your changes under this in a bullet point list --->
- Fix armor stand placement being blocked by EntityPlaceEvent
players were unable to place armor stands due to the event being
cancelled in the onArmorStandSpawn handler. The event cancellation
was preventing placement while trying to set defualt gravity

----
### [CI] Changes
*Changes relating to the Continuous Integration of other Plugin APIs, Github Workflows, Issue Templates etc.*
<!---- List your changes under this in a bullet point list --->

----
### [DOC] Changes
*Changes relating to plugin Documentation - See the Wiki for more info*
<!---- List your changes under this in a bullet point list --->

----
### [MISC] Changes
*Changes that does not fit in the above list*
<!---- List your changes under this in a bullet point list --->

____
- [ ] I have tested this pull request for defects on a server.
<!--- Place x between [ x ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the ArmorStandEditor Project Owners have the copyright to use and modify my contribution under the ArmorStandEditor [License](https://github.com/Wolfieheart/ArmorStandEditor/blob/master/LICENSE.md) for perpetuity.