### PR TITLE
Add Coreprotect support, other fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,10 @@
             <id>codemc-repo</id>
             <url>https://repo.codemc.org/repository/maven-public/</url>
         </repository>
+        <repository>
+            <id>playpro-repo</id>
+            <url>https://maven.playpro.com</url>
+        </repository>
     </repositories>
 
     <dependencyManagement>
@@ -242,6 +246,14 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.34</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- CoreProtect Support -->
+        <dependency>
+            <groupId>net.coreprotect</groupId>
+            <artifactId>coreprotect</artifactId>
+            <version>23.1</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/io/github/rypofalem/armorstandeditor/ArmorStandEditorPlugin.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/ArmorStandEditorPlugin.java
@@ -19,6 +19,7 @@
 
 package io.github.rypofalem.armorstandeditor;
 
+import io.github.rypofalem.armorstandeditor.coreprotect.CoreProtectExtension;
 import io.github.rypofalem.armorstandeditor.language.Language;
 import io.github.rypofalem.armorstandeditor.utils.MinecraftVersion;
 import io.github.rypofalem.armorstandeditor.utils.VersionUtil;
@@ -54,7 +55,7 @@ public class ArmorStandEditorPlugin extends JavaPlugin {
     //!!! DO NOT REMOVE THESE UNDER ANY CIRCUMSTANCES - Required for BStats and UpdateChecker !!!
     public static final String HANGAR_RELEASE_CHANNEL = "Wolfieheart/ArmorStandEditor-Reborn/Release";  //Used for Update Checker
     private static final int PLUGIN_ID = 12668;             //Used for BStats Metrics
-    public Debug debug;
+    public final Debug debug = new Debug(this);
 
     private NamespacedKey iconKey;
     private static ArmorStandEditorPlugin instance;
@@ -126,7 +127,7 @@ public class ArmorStandEditorPlugin extends JavaPlugin {
     //Debugging Options.... Not Exposed globally
     boolean debugFlag;
 
-    private static ArmorStandEditorPlugin plugin;
+    private Scheduler scheduler;
 
     public ArmorStandEditorPlugin() {
         instance = this;
@@ -134,6 +135,7 @@ public class ArmorStandEditorPlugin extends JavaPlugin {
 
     @Override
     public void onEnable() {
+        scheduler = new Scheduler(this);
 
         if (!getHasFolia())
             scoreboard = Objects.requireNonNull(this.getServer().getScoreboardManager()).getMainScoreboard();
@@ -222,6 +224,7 @@ public class ArmorStandEditorPlugin extends JavaPlugin {
 
         getServer().getPluginManager().registerEvents(editorManager, this);
 
+        CoreProtectExtension.init(this);
     }
 
 
@@ -540,7 +543,6 @@ public class ArmorStandEditorPlugin extends JavaPlugin {
         debugFlag = getConfig().getBoolean("debugFlag", false);
         if (debugFlag) {
             getServer().getLogger().log(Level.INFO, "[ArmorStandEditor-Debug] ArmorStandEditor Debug Mode is now ENABLED! Use this ONLY for testing Purposes. If you can see this and you have debug disabled, please report it as a bug!");
-            debug = new Debug(this);
         }
 
     }
@@ -656,9 +658,6 @@ public class ArmorStandEditorPlugin extends JavaPlugin {
 
     private void runWarningsFolia() {
         getLogger().warning("Scoreboards currently do not work on Folia. Scoreboard Coloring will not work");
-        getLogger().warning("This also means the Teams for ASLocked and AS-InUse will also not work. Sever Owners if you see this: ");
-        getLogger().warning("This is not a bug. Warn Players to be careful with ArmorStands and 2 people using them at the same time.... ");
-        getLogger().warning(".... as this is known to cause Duplicate Items. Also warn you server moderation team. ");
     }
 
 
@@ -676,6 +675,10 @@ public class ArmorStandEditorPlugin extends JavaPlugin {
 
     public String getASEVersion() {
         return ASE_VERSION;
+    }
+
+    public Scheduler getScheduler() {
+        return scheduler;
     }
 
 }

--- a/src/main/java/io/github/rypofalem/armorstandeditor/CommandEx.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/CommandEx.java
@@ -72,7 +72,7 @@ public class CommandEx implements CommandExecutor, TabCompleter {
 
     public CommandEx(ArmorStandEditorPlugin armorStandEditorPlugin) {
         this.plugin = armorStandEditorPlugin;
-        this.debug = new Debug(plugin);
+        this.debug = plugin.debug;
     }
 
     @Override

--- a/src/main/java/io/github/rypofalem/armorstandeditor/Debug.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/Debug.java
@@ -4,15 +4,15 @@ package io.github.rypofalem.armorstandeditor;
 import java.util.logging.Level;
 
 public class Debug {
-
-    private ArmorStandEditorPlugin plugin;
+    private final ArmorStandEditorPlugin plugin;
 
     public Debug(ArmorStandEditorPlugin plugin) {
         this.plugin = plugin;
     }
 
     public void log(String msg) {
-        if (!plugin.isDebug()) return;
-        plugin.getLogger().log(Level.INFO, "[ArmorStandEditor-Debug] {0}", msg);
+        if (plugin.isDebug()) {
+            plugin.getLogger().log(Level.INFO, "[ArmorStandEditor-Debug] {0}", msg);
+        }
     }
 }

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
@@ -87,8 +87,8 @@ public class PlayerEditor {
     public PlayerEditor(UUID uuid, ArmorStandEditorPlugin plugin) {
         this.uuid = uuid;
         this.plugin = plugin;
-        this.debug = new Debug(plugin);
-        this.scheduler = new Scheduler(plugin);
+        this.debug = plugin.debug;
+        this.scheduler = plugin.getScheduler();
 
         eMode = EditMode.NONE;
         adjMode = AdjustmentMode.COARSE;
@@ -737,6 +737,10 @@ public class PlayerEditor {
 
     public Player getPlayer() {
         return plugin.getServer().getPlayer(getUUID());
+    }
+
+    public Scheduler getScheduler() {
+        return scheduler;
     }
 
     public UUID getUUID() {

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
@@ -93,8 +93,8 @@ public class PlayerEditorManager implements Listener {
 
     PlayerEditorManager(ArmorStandEditorPlugin plugin) {
         this.plugin = plugin;
-        this.debug = new Debug(plugin);
-        this.scheduler = new Scheduler(plugin);
+        this.debug = plugin.debug;
+        this.scheduler = plugin.getScheduler();
 
         players = new HashMap<>();
         coarseAdj = Util.FULL_CIRCLE / plugin.coarseRot;

--- a/src/main/java/io/github/rypofalem/armorstandeditor/Scheduler.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/Scheduler.java
@@ -3,6 +3,7 @@ package io.github.rypofalem.armorstandeditor;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
 
 /**
@@ -41,8 +42,7 @@ public class Scheduler {
     /** Run a delayed task */
     public void runTaskLater(Runnable task, long delayTicks) {
         if (isFolia) {
-            // Folia has no built-in delay, so we wrap a delayed Paper task
-            Bukkit.getScheduler().runTaskLater(plugin, () -> Bukkit.getGlobalRegionScheduler().run(plugin, t -> task.run()), delayTicks);
+            Bukkit.getGlobalRegionScheduler().runDelayed(plugin, t -> task.run(), delayTicks);
         } else {
             Bukkit.getScheduler().runTaskLater(plugin, task, delayTicks);
         }
@@ -51,11 +51,7 @@ public class Scheduler {
     /** Run a repeating task (Folia-compatible) */
     public void runTaskTimer(Runnable task, long delayTicks, long periodTicks) {
         if (isFolia) {
-            // Schedule first run after delay
-            runTaskLater(() -> {
-                task.run();
-                scheduleRepeating(task, periodTicks);
-            }, delayTicks);
+            Bukkit.getGlobalRegionScheduler().runAtFixedRate(plugin, t -> task.run(), delayTicks, periodTicks);
         } else {
             Bukkit.getScheduler().runTaskTimer(plugin, task, delayTicks, periodTicks);
         }
@@ -87,6 +83,15 @@ public class Scheduler {
         }
     }
 
+    public void dropItem(Location location, ItemStack item) {
+        Runnable task = () -> location.getWorld().dropItemNaturally(location, item);
+        if (isFolia) {
+            Bukkit.getRegionScheduler().run(plugin, location, t -> task.run());
+        } else {
+            task.run();
+        }
+    }
+
     /** Run a task at a specific location (region-safe) */
     public void runAtLocation(Location location, Runnable task) {
         if (isFolia) {
@@ -99,7 +104,7 @@ public class Scheduler {
     /** Run an async task (Paper only, Folia falls back to region scheduler) */
     public void runAsync(Runnable task) {
         if (isFolia) {
-            Bukkit.getGlobalRegionScheduler().run(plugin, t -> task.run());
+            Bukkit.getAsyncScheduler().runNow(plugin, t -> task.run());
         } else {
             Bukkit.getScheduler().runTaskAsynchronously(plugin, task);
         }

--- a/src/main/java/io/github/rypofalem/armorstandeditor/UpdateChecker.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/UpdateChecker.java
@@ -7,7 +7,6 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
-import org.bukkit.scheduler.BukkitScheduler;
 import io.github.rypofalem.armorstandeditor.utils.VersionUtil;
 
 import javax.net.ssl.HttpsURLConnection;
@@ -20,19 +19,19 @@ public class UpdateChecker implements Listener {
     private static final String HANGAR_URL = "https://hangar.papermc.io/api/v1/projects/Wolfieheart/ArmorStandEditor-Reborn/latest?channel=Release";
 
     private static ArmorStandEditorPlugin plugin = null;
-    private static BukkitScheduler taskScheduler = null;
+    private static Scheduler taskScheduler = null;
     private final String pluginVersion;
     private String versionOnHangar;
     private boolean updateAvailable;
 
     public UpdateChecker(ArmorStandEditorPlugin plugin) {
         UpdateChecker.plugin = plugin;
-        taskScheduler = plugin.getServer().getScheduler();
+        taskScheduler = plugin.getScheduler();
         pluginVersion = plugin.getPluginMeta().getVersion();
     }
 
     public void checkForUpdates() {
-        taskScheduler.runTaskAsynchronously(plugin, () -> {
+        taskScheduler.runAsync(() -> {
             try {
 
                 HttpsURLConnection connection = (HttpsURLConnection) URI
@@ -54,7 +53,7 @@ public class UpdateChecker implements Listener {
             updateAvailable = VersionUtil.fromString(versionOnHangar).isNewerThanOrEquals(VersionUtil.fromString(pluginVersion));
             if (!updateAvailable) return;
 
-            taskScheduler.runTaskAsynchronously(plugin, () -> {
+            taskScheduler.runAsync(() -> {
                 plugin.getLogger().info("A new version of ArmorStandEditor-Reborn is available! (Version " + versionOnHangar + ")");
                 plugin.getLogger().info("Download it from: https://hangar.papermc.io/Wolfieheart/ArmorStandEditor-Reborn");
             });

--- a/src/main/java/io/github/rypofalem/armorstandeditor/coreprotect/CoreProtectExtension.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/coreprotect/CoreProtectExtension.java
@@ -18,10 +18,10 @@ public class CoreProtectExtension {
 
     public static void logChange(Player player, ArmorStand armorStand, @NotNull ItemStack[] oldContents, @NotNull ItemStack[] newContents) {
         if (plugin == null || !plugin.getServer().getPluginManager().isPluginEnabled("CoreProtect")) return;
-        if (!Config.getConfig(player.getWorld()).ITEM_TRANSACTIONS) {
-            return;
-        }
         try { // As this is unstable due to being copied from net.coreprotect.listener.player.ArmorStandManipulateListener, it is prone to errors with updates
+            if (!Config.getConfig(player.getWorld()).ITEM_TRANSACTIONS) {
+                return;
+            }
             for (int i = 0; i < oldContents.length; i++) {
                 ItemStack oldItem = oldContents[i];
                 ItemStack newItem = newContents[i];

--- a/src/main/java/io/github/rypofalem/armorstandeditor/coreprotect/CoreProtectExtension.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/coreprotect/CoreProtectExtension.java
@@ -1,0 +1,43 @@
+package io.github.rypofalem.armorstandeditor.coreprotect;
+
+import io.github.rypofalem.armorstandeditor.ArmorStandEditorPlugin;
+import net.coreprotect.config.Config;
+import net.coreprotect.listener.player.PlayerInteractEntityListener;
+import org.bukkit.Material;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+public class CoreProtectExtension {
+    private static ArmorStandEditorPlugin plugin;
+
+    public static void init(ArmorStandEditorPlugin plugin) {
+        CoreProtectExtension.plugin = plugin;
+    }
+
+    public static void logChange(Player player, ArmorStand armorStand, @NotNull ItemStack[] oldContents, @NotNull ItemStack[] newContents) {
+        if (plugin == null || !plugin.getServer().getPluginManager().isPluginEnabled("CoreProtect")) return;
+        if (!Config.getConfig(player.getWorld()).ITEM_TRANSACTIONS) {
+            return;
+        }
+        try { // As this is unstable due to being copied from net.coreprotect.listener.player.ArmorStandManipulateListener, it is prone to errors with updates
+            for (int i = 0; i < oldContents.length; i++) {
+                ItemStack oldItem = oldContents[i];
+                ItemStack newItem = newContents[i];
+                if (oldItem.equals(newItem)) continue;
+
+                if (!oldItem.getType().isAir()) {
+                    oldContents[i] = oldItem.clone();
+                }
+                if (!newItem.getType().isAir()) {
+                    newContents[i] = newItem.clone();
+                }
+            }
+
+            PlayerInteractEntityListener.queueContainerSpecifiedItems(player.getName(), Material.ARMOR_STAND, new Object[]{oldContents, newContents}, armorStand.getLocation(), false);
+        } catch (Throwable throwable) {
+            plugin.getSLF4JLogger().warn("Error/Exception while logging with CoreProtect", throwable);
+        }
+    }
+}

--- a/src/main/java/io/github/rypofalem/armorstandeditor/coreprotect/CoreProtectExtension.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/coreprotect/CoreProtectExtension.java
@@ -11,13 +11,16 @@ import org.jetbrains.annotations.NotNull;
 
 public class CoreProtectExtension {
     private static ArmorStandEditorPlugin plugin;
+    private static boolean enabled = false;
 
     public static void init(ArmorStandEditorPlugin plugin) {
         CoreProtectExtension.plugin = plugin;
+        enabled = plugin.getServer().getPluginManager().isPluginEnabled("CoreProtect");
+
     }
 
     public static void logChange(Player player, ArmorStand armorStand, @NotNull ItemStack[] oldContents, @NotNull ItemStack[] newContents) {
-        if (plugin == null || !plugin.getServer().getPluginManager().isPluginEnabled("CoreProtect")) return;
+        if (!enabled) return;
         try { // As this is unstable due to being copied from net.coreprotect.listener.player.ArmorStandManipulateListener, it is prone to errors with updates
             if (!Config.getConfig(player.getWorld()).ITEM_TRANSACTIONS) {
                 return;

--- a/src/main/java/io/github/rypofalem/armorstandeditor/menu/EquipmentMenu.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/menu/EquipmentMenu.java
@@ -22,6 +22,7 @@ package io.github.rypofalem.armorstandeditor.menu;
 import io.github.rypofalem.armorstandeditor.Debug;
 import io.github.rypofalem.armorstandeditor.PlayerEditor;
 
+import io.github.rypofalem.armorstandeditor.coreprotect.CoreProtectExtension;
 import io.papermc.paper.datacomponent.DataComponentTypes;
 
 import io.papermc.paper.datacomponent.item.ItemLore;
@@ -31,10 +32,17 @@ import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerArmorStandManipulateEvent;
 import org.bukkit.inventory.EntityEquipment;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.persistence.PersistentDataType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
 
 
 @SuppressWarnings("UnstableApiUsage")
@@ -43,12 +51,13 @@ public class EquipmentMenu {
     private Debug debug;
     private PlayerEditor pe;
     private ArmorStand armorstand;
-    ItemStack helmet, chest, pants, feetsies, rightHand, leftHand;
+    ItemStack helmet, chest, pants, feetsies, rightHand, leftHand = ItemStack.of(Material.AIR);
+    ItemStack oldHelmet, oldChest, oldPants, oldFeetsies, oldRightHand, oldLeftHand = ItemStack.of(Material.AIR);
 
     public EquipmentMenu(PlayerEditor pe, ArmorStand as) {
         this.pe = pe;
         this.armorstand = as;
-        this.debug = new Debug(pe.plugin);
+        this.debug = pe.plugin.debug;
         Component name = pe.plugin.getLang().getMessage("equiptitle", "menutitle");
         menuInv = Bukkit.createInventory(pe.getManager().getEquipmentHolder(), 18, name);
     }
@@ -62,6 +71,12 @@ public class EquipmentMenu {
         ItemStack feetsies = equipment.getBoots();
         ItemStack rightHand = equipment.getItemInMainHand();
         ItemStack leftHand = equipment.getItemInOffHand();
+        oldHelmet = helmet;
+        oldChest = chest;
+        oldPants = pants;
+        oldFeetsies = feetsies;
+        oldRightHand = rightHand;
+        oldLeftHand = leftHand;
         equipment.clear();
 
         ItemStack disabledIcon = ItemStack.of(Material.BARRIER);
@@ -123,27 +138,73 @@ public class EquipmentMenu {
     }
 
     public void equipArmorstand() {
-        helmet = menuInv.getItem(9);
-        chest = menuInv.getItem(10);
-        pants = menuInv.getItem(11);
-        feetsies = menuInv.getItem(12);
-        rightHand = menuInv.getItem(13);
-        leftHand = menuInv.getItem(14);
+        helmet = notNull(menuInv.getItem(9));
+        chest = notNull(menuInv.getItem(10));
+        pants = notNull(menuInv.getItem(11));
+        feetsies = notNull(menuInv.getItem(12));
+        rightHand = notNull(menuInv.getItem(13));
+        leftHand = notNull(menuInv.getItem(14));
 
-        debug.log("Equipping the ArmorStand with the following items: ");
-        debug.log("Helmet: " + helmet);
-        debug.log("Chest: " + chest);
-        debug.log("Chest: " + chest);
-        debug.log("Pants: " + pants);
-        debug.log("Boots: " + feetsies);
-        debug.log("R-Hand: " + rightHand);
-        debug.log("L-Hand: " + leftHand);
+        EntityEquipment equipment = armorstand.getEquipment();;
+        equipment.setHelmet(helmet);
+        equipment.setChestplate(chest);
+        equipment.setLeggings(pants);
+        equipment.setBoots(feetsies);
+        equipment.setItemInMainHand(rightHand);
+        equipment.setItemInOffHand(leftHand);
 
-        armorstand.getEquipment().setHelmet(helmet);
-        armorstand.getEquipment().setChestplate(chest);
-        armorstand.getEquipment().setLeggings(pants);
-        armorstand.getEquipment().setBoots(feetsies);
-        armorstand.getEquipment().setItemInMainHand(rightHand);
-        armorstand.getEquipment().setItemInOffHand(leftHand);
+        checkForChanges();
+    }
+
+    private void checkForChanges() {
+        debug.log("Equipping ArmorStand and checking changes.");
+        Player player = pe.getPlayer();
+        ItemStack[] oldArray = new ItemStack[] { oldHelmet, oldChest, oldPants, oldFeetsies, oldRightHand, oldLeftHand };
+        ItemStack[] newArray = new ItemStack[] { helmet, chest, pants, feetsies, rightHand, leftHand };
+
+        boolean change = false;
+        if (hasChanged(oldHelmet, helmet)) {
+            debug.log("Helmet changed from " + oldHelmet + " to " + helmet);
+            oldHelmet = helmet;
+            change = true;
+        }
+        if (hasChanged(oldChest, chest)) {
+            debug.log("Chest changed from " + oldChest + " to " + chest);
+            oldChest = chest;
+            change = true;
+        }
+        if (hasChanged(oldPants, pants)) {
+            debug.log("Pants changed from " + oldPants + " to " + pants);
+            oldPants = pants;
+            change = true;
+        }
+        if (hasChanged(oldFeetsies, feetsies)) {
+            debug.log("Boots changed from " + oldFeetsies + " to " + feetsies);
+            oldFeetsies = feetsies;
+            change = true;
+        }
+        if (hasChanged(oldRightHand, rightHand)) {
+            debug.log("R-Hand changed from " + oldRightHand + " to " + rightHand);
+            oldRightHand = rightHand;
+            change = true;
+        }
+        if (hasChanged(oldLeftHand, leftHand)) {
+            debug.log("L-Hand changed from " + oldLeftHand + " to " + leftHand);
+            oldLeftHand = leftHand;
+            change = true;
+        }
+
+        if (change) {
+            CoreProtectExtension.logChange(player, armorstand, oldArray, newArray);
+        }
+    }
+
+    private boolean hasChanged(@Nullable ItemStack before, @Nullable ItemStack after) {
+        if (before == null && after == null) return false;
+        return before == null || !before.equals(after);
+    }
+
+    private ItemStack notNull(@Nullable ItemStack item) {
+        return item != null ? item : ItemStack.of(Material.AIR);
     }
 }

--- a/src/main/java/io/github/rypofalem/armorstandeditor/menu/Menu.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/menu/Menu.java
@@ -44,7 +44,7 @@ public class Menu {
 
     public Menu(PlayerEditor pe) {
         this.pe = pe;
-        this.debug = new Debug(pe.plugin);
+        this.debug = pe.plugin.debug;
         name = pe.plugin.getLang().getMessage("mainmenutitle", "menutitle");
         menuInv = Bukkit.createInventory(pe.getManager().getMenuHolder(), 54, name);
         fillInventory();

--- a/src/main/java/io/github/rypofalem/armorstandeditor/menu/PresetArmorPosesMenu.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/menu/PresetArmorPosesMenu.java
@@ -56,7 +56,7 @@ public class PresetArmorPosesMenu {
     public PresetArmorPosesMenu(PlayerEditor pe, ArmorStand as) {
         this.pe = pe;
         this.armorStand = as;
-        this.debug = new Debug(pe.plugin);
+        this.debug = pe.plugin.debug;
         name = plugin.getLang().getMessage("presettitle", "menutitle");
         menuInv = Bukkit.createInventory(pe.getManager().getPresetHolder(), 36, name);
     }

--- a/src/main/java/io/github/rypofalem/armorstandeditor/menu/SizeMenu.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/menu/SizeMenu.java
@@ -34,7 +34,7 @@ public class SizeMenu extends ASEHolder {
     public SizeMenu(PlayerEditor pe, ArmorStand as) {
         this.pe = pe;
         this.as = as;
-        this.debug = new Debug(pe.plugin);
+        this.debug = pe.plugin.debug;
         name = pe.plugin.getLang().getMessage("sizeMenu", "menutitle");
         menuInv = Bukkit.createInventory(pe.getManager().getSizeMenuHolder(), 27, name);
     }

--- a/src/main/java/io/github/rypofalem/armorstandeditor/protections/TownyProtection.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/protections/TownyProtection.java
@@ -41,7 +41,7 @@ public class TownyProtection implements Protection {
 
     public TownyProtection() {
         plugin = ArmorStandEditorPlugin.instance();
-        debug = new Debug(plugin);
+        debug = plugin.debug;
         tEnabled = Bukkit.getPluginManager().isPluginEnabled("Towny");
     }
 


### PR DESCRIPTION
#### Description:
<!--- Describe your Pull Request's purpose here please. --->
Add CoreProtect support

----
### [CORE] Changes
*Changes to the core of the plugin - Performance Fixes, Bug Fixes, New Features, New Permission Nodes, New Config Options etc.* 
<!---- List your changes under this in a bullet point list --->
- Log ArmorStand withdrawals/deposits with coreprotect
- Use central Scheduler & debug instance
- Remove old warning about Folia & Teams for armor stand lock
- Update EquipmentMenu to compare before & after changes
- Fix Folia support in Scheduler
- Fix UpdateChecker not working on folia

<img width="496" height="152" alt="image" src="https://github.com/user-attachments/assets/18792bcd-bfb9-474a-884b-fbbfb36419e9" />

____
- [x] I have tested this pull request for defects on a server.
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the ArmorStandEditor Project Owners have the copyright to use and modify my contribution under the ArmorStandEditor [License](https://github.com/Wolfieheart/ArmorStandEditor/blob/master/LICENSE.md) for perpetuity.