### PR TITLE
Use live-event for TownyProtection, rather than a Cache

### DIFF
--- a/src/main/java/io/github/rypofalem/armorstandeditor/protections/TownyProtection.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/protections/TownyProtection.java
@@ -20,8 +20,7 @@ package io.github.rypofalem.armorstandeditor.protections;
 
 import com.palmergames.bukkit.towny.TownyAPI;
 
-import com.palmergames.bukkit.towny.object.TownyPermission;
-import com.palmergames.bukkit.towny.utils.PlayerCacheUtil;
+import com.palmergames.bukkit.towny.event.executors.TownyActionEventExecutor;
 import io.github.rypofalem.armorstandeditor.ArmorStandEditorPlugin;
 import io.github.rypofalem.armorstandeditor.Debug;
 import org.bukkit.Bukkit;
@@ -72,14 +71,7 @@ public class TownyProtection implements Protection {
                 return false;
             }
         }
-
-        // --- towny permission check ---
-        return PlayerCacheUtil.getCachePermission(
-                player,
-                entityOnBlock.getLocation(),            // use the stand's actual location
-                Material.ARMOR_STAND,                   // treat the target as an ArmorStand
-                TownyPermission.ActionType.BUILD
-        );
+        return TownyActionEventExecutor.canBuild(player, entityOnBlock.getLocation(), Material.ARMOR_STAND);
     }
 }
 


### PR DESCRIPTION
#### Description:
<!--- Describe your Pull Request's purpose here please. --->
Issue: Plugins that cancel Towny's build/destroy events have no effect on ArmorStandEditor, as ASE uses Towny's PlayerCache, that does not fire a live event.

____
- [ ] I have tested this pull request for defects on a server.
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the ArmorStandEditor Project Owners have the copyright to use and modify my contribution under the ArmorStandEditor [License](https://github.com/Wolfieheart/ArmorStandEditor/blob/master/LICENSE.md) for perpetuity.