### PR TITLE
🐛 fix(PlayerEditorManager): change scheduler task to run for entity instead of globally

### DIFF
--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
@@ -200,7 +200,7 @@ public class PlayerEditorManager implements Listener {
                     // minecraft will set the name after this event even if the event is cancelled.
                     // change it 1 tick later to apply formatting without it being overwritten
                     final Component finalgetName = getName;
-                    scheduler.runTask(() -> {
+                    scheduler.runForEntity(as, () -> {
                         as.customName(finalgetName);
                         as.setCustomNameVisible(true);
                     });


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the ArmorStandEditor project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect ArmorStandEditor, making your code available to us to use indefinitely. --->
#### Description:
<!--- Describe your Pull Request's purpose here please. --->

----
### [CORE] Changes
*Changes to the core of the plugin - Performance Fixes, Bug Fixes, New Features, New Permission Nodes, New Config Options etc.* 
Fixes: 
```
java.lang.IllegalStateException: Thread failed main thread check: Accessing entity state off owning region's thread, context=[thread=Folia Region Scheduler Thread #17,class=io.papermc.paper.threadedregions.TickRegionScheduler$TickThreadRunner,region={null}], entity={root=[{type=ArmorStand,id=8998999,uuid=51419824-6ea5-4837-b7eb-ca8decf1daa0,pos=(-7,037.500,89.000,30,971.500),mot=(0.000,0.000,0.000),aabb=AABB[-7037.75, 89.0, 30971.25] -> [-7037.25, 90.97500002384186, 30971.75],removed=null,has_vehicle=false,passenger_count=0], vehicle=[{null}], passengers=[]
    at ca.spottedleaf.moonrise.common.util.TickThread.ensureTickThread(TickThread.java:98)
    at org.bukkit.craftbukkit.entity.CraftArmorStand.getHandle(CraftArmorStand.java:20)
    at org.bukkit.craftbukkit.entity.CraftArmorStand.getHandle(CraftArmorStand.java:12)
    at org.bukkit.craftbukkit.entity.CraftEntity.customName(CraftEntity.java:679)
    at io.github.rypofalem.armorstandeditor.PlayerEditorManager.lambda$onArmorStandInteract$0(PlayerEditorManager.java:204)
    at io.github.rypofalem.armorstandeditor.Scheduler.lambda$runTask$0(Scheduler.java:36)
    at io.papermc.paper.threadedregions.scheduler.FoliaGlobalRegionScheduler$GlobalScheduledTask.run(FoliaGlobalRegionScheduler.java:178)
    at io.papermc.paper.threadedregions.scheduler.FoliaGlobalRegionScheduler.tick(FoliaGlobalRegionScheduler.java:36)
    at io.papermc.paper.threadedregions.RegionizedServer.globalTick(RegionizedServer.java:348)
    at io.papermc.paper.threadedregions.RegionizedServer$GlobalTickTickHandle.tickRegion(RegionizedServer.java:192)
    at io.papermc.paper.threadedregions.TickRegionScheduler$RegionScheduleHandle.runTick(TickRegionScheduler.java:524)
    at io.canvasmc.canvas.tick.AffinitySchedulerThreadPool$TickThreadRunner.run(AffinitySchedulerThreadPool.java:635)
    at java.lang.Thread.run(Thread.java:1474)
```


----
### [CI] Changes
*Changes relating to the Continuous Integration of other Plugin APIs, Github Workflows, Issue Templates etc.*
<!---- List your changes under this in a bullet point list --->

----
### [DOC] Changes
*Changes relating to plugin Documentation - See the Wiki for more info*
<!---- List your changes under this in a bullet point list --->

----
### [MISC] Changes
*Changes that does not fit in the above list*
<!---- List your changes under this in a bullet point list --->


____
- [x] I have tested this pull request for defects on a server.
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the ArmorStandEditor Project Owners have the copyright to use and modify my contribution under the ArmorStandEditor [License](https://github.com/Wolfieheart/ArmorStandEditor/blob/master/LICENSE.md) for perpetuity.